### PR TITLE
Two supply chain gates, every action pinned to a commit, 98 semgrep findings to zero

### DIFF
--- a/.github/scripts/dependency_gate.py
+++ b/.github/scripts/dependency_gate.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Decide a pull request from GitHub's dependency review data.
+
+    gh api "repos/$REPO/dependency-graph/compare/$BASE...$HEAD" > deps.json
+    python .github/scripts/dependency_gate.py deps.json
+
+Why this exists next to actions/dependency-review-action
+--------------------------------------------------------
+The action already fails a pull request that ADDS a dependency with a known
+vulnerability, and it does that well. It cannot do the other half. Its own
+documentation is explicit: "If we can't detect the license for a dependency we
+will inform you, but the action won't fail."
+
+This project is GPL-3.0 and ships a binary, so an unidentified licence is not an
+informational note. It is the one answer nobody can act on, because whether the
+thing may be distributed at all is exactly what it fails to say. The same data
+is read here and an unknown licence blocks, like a denied one. The REST field is
+documented as "string or null", and null is what "not determined" looks like.
+
+Why this lives in .github/scripts and not in tools
+--------------------------------------------------
+tools/ is outside this repository by an owner decision from 2026-08-01, on the
+grounds that it is never shipped. This script is the opposite: CI checks out the
+repository and runs it, so it has to travel with the repository. That also puts
+it under the guards that read public text, which is correct for a file the world
+can see.
+
+Scope
+-----
+Only dependencies that a pull request ADDS. Removing something never creates an
+obligation, and re-checking what is already in the tree would make every pull
+request answer for decisions taken years ago.
+"""
+import argparse
+import json
+import sys
+
+# SPDX identifiers this project may distribute alongside its own code.
+#
+# The criterion is recorded rather than invented here: LICENSING.md states that
+# a library must be compatible with GPL-3.0, that Apache-2.0, MIT, BSD, LGPL and
+# MPL-2.0 qualify, and that GPL-2.0-only does not. GPL-2.0-only is therefore
+# ABSENT on purpose. It is famously incompatible with GPL-3.0 and it is exactly
+# the kind of entry that looks fine in a list of open source licences and is not.
+#
+# Every identifier below except the last was measured in this repository's own
+# dependency graph on 2026-08-27, so the list describes what we actually have
+# rather than what somebody expected us to have.
+ALLOWED = frozenset({
+    "0BSD", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "CC0-1.0", "ISC",
+    "MIT", "MIT-0", "MPL-2.0", "Unlicense", "Zlib",
+    "LGPL-2.1-only", "LGPL-2.1-or-later", "LGPL-3.0-only", "LGPL-3.0-or-later",
+    "GPL-3.0-only", "GPL-3.0-or-later",
+
+    # The Go project's PATENTS file, which scancode names and GitHub reports
+    # beside the BSD licence of golang.org/x/sys, x/net and x/image. Read on
+    # 2026-08-27 from the pinned module rather than recalled: it is an
+    # "Additional IP Rights Grant" that GIVES a patent licence. It grants rights
+    # and restricts no distribution, so it cannot make a dependency unusable
+    # here. Without this entry three modules already in the tree would be
+    # blocked the next time they moved.
+    "LicenseRef-scancode-google-patent-license-golang",
+})
+
+# Packages whose licence GitHub cannot resolve and which a person has already
+# looked at. A name here is a decision with a reason, not a way to make a red
+# build green - and it names one package, never a whole ecosystem.
+EXCEPTIONS = {
+    # (empty on purpose - add "name": "why this is fine" when it happens)
+}
+
+# GitHub reports license: null for every action, measured on this repository on
+# 2026-08-27: seven of seven came back null while all 36 Go modules carried a
+# real licence.
+#
+# They are skipped, and not for convenience. An action is CI machinery that
+# never reaches a user, so it creates no distribution obligation, which is the
+# thing an unknown licence is dangerous for. Keeping them would block every pull
+# request that touches a workflow for ever, and a gate that always fires is a
+# gate people learn to bypass.
+#
+# What actions ARE checked for is stricter and lives next door: every one must
+# name a commit rather than a tag, which TestEveryActionIsPinnedToACommitRatherThanATag
+# refuses to let slide. That guard is what makes this skip honest.
+SKIPPED_ECOSYSTEMS = frozenset({"actions"})
+
+
+def added(review):
+    return [d for d in review
+            if str(d.get("change_type", "")) == "added"
+            and str(d.get("ecosystem", "")).lower() not in SKIPPED_ECOSYSTEMS]
+
+
+def parts_of(expression):
+    """The individual identifiers in an SPDX expression.
+
+    Both AND and OR are split the same way and every part has to be allowed.
+    For AND that is simply correct. For OR it is stricter than the licence
+    requires, because an OR lets the user pick the half they like - and that is
+    deliberate: being wrong this way can only block a dependency somebody then
+    records a decision about, while the generous reading can let one through
+    unnoticed. A blocked dependency asks a question. An admitted one does not.
+    """
+    flat = str(expression).replace(" AND ", " OR ")
+    return [p.strip("() ") for p in flat.split(" OR ") if p.strip("() ")]
+
+
+def verdict(dependency):
+    """("ok" | "unknown" | "denied", licence) for one added dependency."""
+    licence = dependency.get("license")
+    name = str(dependency.get("name", "?"))
+    if name in EXCEPTIONS:
+        return "ok", licence
+    if licence is None or not str(licence).strip():
+        return "unknown", licence
+    if all(part in ALLOWED for part in parts_of(licence)):
+        return "ok", licence
+    return "denied", licence
+
+
+def split(review):
+    blocked, passed = [], []
+    for dependency in added(review):
+        state, licence = verdict(dependency)
+        row = (state, str(dependency.get("name", "?")),
+               str(dependency.get("version", "?")), licence,
+               str(dependency.get("scope", "?")))
+        (passed if state == "ok" else blocked).append(row)
+    return blocked, passed
+
+
+def report_lines(blocked, passed):
+    lines = []
+    if blocked:
+        lines.append("blocked - a licence that is denied or could not be determined:")
+        for state, name, version, licence, scope in blocked:
+            lines.append("  %-8s %s %s  licence=%s  scope=%s"
+                         % (state, name, version, licence, scope))
+        lines.append("")
+        lines.append("An unknown licence blocks on purpose. This project is GPL-3.0 and ships a")
+        lines.append("binary, so 'we could not tell' is the one answer nobody can act on. Read the")
+        lines.append("LICENSE file of the pinned version, then record the decision in")
+        lines.append(".github/scripts/dependency_gate.py, in ALLOWED or in EXCEPTIONS.")
+    if passed:
+        lines.append("allowed (%d): %s" % (
+            len(passed), ", ".join("%s %s (%s)" % (n, v, lic) for _s, n, v, lic, _sc in passed)))
+    lines.append("dependency gate: %d blocked, %d allowed" % (len(blocked), len(passed)))
+    return lines
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("review", help="JSON from the dependency review API")
+    args = parser.parse_args(argv)
+    try:
+        with open(args.review, encoding="utf-8") as handle:
+            review = json.load(handle)
+    except (OSError, ValueError) as exc:
+        # A gate that cannot read its input has not passed anything. The API
+        # answers 403 for some repository shapes, and that has to look like a
+        # failure rather than an empty list of problems.
+        print("dependency gate: cannot read %s: %s" % (args.review, exc), file=sys.stderr)
+        return 2
+    if not isinstance(review, list):
+        print("dependency gate: expected a list of dependencies, got %s"
+              % type(review).__name__, file=sys.stderr)
+        return 2
+    blocked, passed = split(review)
+    for line in report_lines(blocked, passed):
+        print(line)
+    return 1 if blocked else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/semgrep_gate.py
+++ b/.github/scripts/semgrep_gate.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Decide a run from a Semgrep JSON report.
+
+    semgrep scan --config p/default --json --output semgrep.json
+    python .github/scripts/semgrep_gate.py semgrep.json
+
+Why this exists rather than `semgrep --severity ERROR --error`
+--------------------------------------------------------------
+Because that flag does not mean what it reads like. `--severity` accepts INFO,
+WARNING and ERROR only, while a rule may declare the newer scale, and rules in
+the registry do. A gate built on the flag would silently ignore exactly the
+severities it was asked to block.
+
+Why the exit code of the scanner is not the answer
+---------------------------------------------------
+Measured on the machine this project is developed on, 2026-08-27, semgrep
+1.175.0: the scan failed its own rule validation, printed "RPC subprocess
+failed" four times, **exited 0**, and wrote a 23 byte file containing
+"<ERROR: missing output>" instead of JSON.
+
+A gate reading that exit code would have reported a clean tree. This one read
+the file, failed to parse it, and exited 2. That is the whole design in one
+measurement: a scanner that fails can succeed, so the report is the answer and
+the exit code is not.
+
+What blocks
+-----------
+Any finding whose severity is ERROR, HIGH or CRITICAL. Everything else is
+printed and passes, because a WARNING here is usually a rule seeing a shape it
+cannot resolve, and a gate that fires on those is a gate nobody reads.
+
+A scan error blocks too. A rule that failed to run is not a rule that found
+nothing, and "the scan was green" must never mean "the scan did not happen".
+Only entries at level "error" count. Measured on this repository: a clean run
+still carries 14 entries at level "warn", all of them semgrep declining to parse
+a shell snippet inside a workflow, and none of them a reason to stop anybody.
+
+Findings decided once and recorded
+-----------------------------------
+Nothing is suppressed here. A finding this project has looked at and settled
+carries a `nosemgrep` comment at the line, with the reason beside it. That is
+deliberate: a list in this file would quieten this gate alone, while the same
+report is also read on semgrep.dev, and a decision that only half the readers
+can see is not recorded, it is hidden.
+"""
+import argparse
+import json
+import sys
+
+BLOCKING = ("ERROR", "HIGH", "CRITICAL")
+
+
+def split(report):
+    """(blocking, passing, scan_errors) out of a semgrep JSON report."""
+    blocking, passing = [], []
+    for result in report.get("results") or []:
+        severity = str((result.get("extra") or {}).get("severity", "")).upper()
+        (blocking if severity in BLOCKING else passing).append(result)
+    errors = [e for e in report.get("errors") or []
+              if str(e.get("level", "")).lower() == "error"]
+    return blocking, passing, errors
+
+
+def describe(result):
+    extra = result.get("extra") or {}
+    start = result.get("start") or {}
+    message = " ".join(str(extra.get("message", "")).split())
+    return "%s:%s  [%s] %s\n      %s" % (
+        result.get("path", "?"), start.get("line", "?"),
+        extra.get("severity", "?"), result.get("check_id", "?"), message[:300])
+
+
+def report_lines(blocking, passing, errors):
+    lines = []
+    if errors:
+        lines.append("scan errors (a rule that could not run is not a rule that passed):")
+        lines += ["  %s: %s" % (e.get("type", "?"),
+                                " ".join(str(e.get("message", "")).split())[:200])
+                  for e in errors]
+    if blocking:
+        lines.append("blocking findings (%s):" % ", ".join(BLOCKING))
+        lines += ["  " + describe(r) for r in blocking]
+        lines.append("")
+        lines.append("If one of these is settled rather than wrong, put a nosemgrep comment on")
+        lines.append("the line with the reason beside it, so semgrep.dev sees the same decision.")
+    if passing:
+        lines.append("other findings (reported, not blocking):")
+        lines += ["  " + describe(r) for r in passing]
+    lines.append("semgrep: %d blocking, %d other, %d scan error(s)"
+                 % (len(blocking), len(passing), len(errors)))
+    return lines
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("report", help="the JSON file semgrep --output wrote")
+    args = parser.parse_args(argv)
+    try:
+        with open(args.report, encoding="utf-8") as handle:
+            report = json.load(handle)
+    except (OSError, ValueError) as exc:
+        # A missing or unparsable report is a failed gate, never a pass. It
+        # means the scan step did not produce what this one was promised, and
+        # that is precisely the shape the measurement above found.
+        print("semgrep gate: cannot read %s: %s" % (args.report, exc), file=sys.stderr)
+        return 2
+    if not isinstance(report, dict):
+        print("semgrep gate: expected a report object, got %s"
+              % type(report).__name__, file=sys.stderr)
+        return 2
+    # A scan that looked at nothing is not a clean scan.
+    #
+    # The failure above produces a file that will not parse, which is loud. This
+    # is the quiet one: a wrong working directory or a configuration that
+    # resolved to nothing still writes a perfectly valid report with an empty
+    # list of results, and every reader downstream would call that a pass.
+    #
+    # What this does NOT prove is how many rules ran, because the report does
+    # not carry that number. It proves that files were read.
+    scanned = (report.get("paths") or {}).get("scanned") or []
+    if not scanned:
+        print("semgrep gate: the report says no file was scanned, so nothing was checked.\n"
+              "A clean run of this repository scans hundreds of files. An empty list means "
+              "the scan ran somewhere else or against nothing, not that the tree is clean.",
+              file=sys.stderr)
+        return 2
+    blocking, passing, errors = split(report)
+    for line in report_lines(blocking, passing, errors):
+        print(line)
+    return 1 if (blocking or errors) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,9 @@ jobs:
       # one runner pays for a C toolchain it already has.
       CGO_ENABLED: ${{ matrix.os == 'macos-latest' && '1' || '0' }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: false
@@ -248,9 +248,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: false
@@ -287,9 +287,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: false
@@ -330,9 +330,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: false
@@ -376,7 +376,7 @@ jobs:
     outputs:
       concurrency: ${{ steps.look.outputs.concurrency }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           # The comparison needs the earlier commit, and the default checkout
           # fetches one.
@@ -452,9 +452,9 @@ jobs:
       # CGO_ENABLED=0 and stays fast.
       CGO_ENABLED: "1"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: false
@@ -508,9 +508,9 @@ jobs:
     env:
       CGO_ENABLED: "0"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: false
@@ -563,9 +563,9 @@ jobs:
     env:
       CGO_ENABLED: "0"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: false
@@ -604,9 +604,9 @@ jobs:
     env:
       CGO_ENABLED: "0"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: false
@@ -632,7 +632,7 @@ jobs:
         # The corpus a failing run leaves behind is the whole value of the run,
         # and it lives in the runner's cache directory rather than the tree.
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: fuzz-findings
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,6 +369,67 @@ jobs:
         # written in the wrong language rather than a typo.
         run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1 run ./...
 
+  semgrep:
+    name: semgrep
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.14"
+
+      - name: the scanner, pinned
+        # Pinned for the reason staticcheck and golangci-lint are pinned: an
+        # unpinned analyser turns somebody else's release into a red build on a
+        # commit that changed nothing.
+        #
+        # Licence read from the pinned version rather than recalled, on
+        # 2026-08-27: LGPL-2.1-or-later, stated by the wheel metadata as a
+        # License-Expression and carried in full beside it. It analyses the tree
+        # and is never linked into either binary, so it is the same kind of
+        # dependency as the two above.
+        run: pip install semgrep==1.175.0
+
+      - name: scan
+        # No account and no token. p/default is fetched anonymously from the
+        # registry, used here, and never carried in this repository, because the
+        # Semgrep Rules License allows the first and forbids the second.
+        #
+        # No --error and no --severity: the scan reports and the gate decides.
+        # --severity knows INFO, WARNING and ERROR only, while registry rules
+        # also carry HIGH and CRITICAL, so a gate built on that flag would
+        # ignore exactly the severities it was asked to block.
+        #
+        # Metrics are off. This repository does not send telemetry about its own
+        # source anywhere, which is the same promise the tool itself makes.
+        #
+        # One rule is excluded, and the reason is measured rather than assumed.
+        # missing-integrity asks for a subresource integrity attribute, which
+        # applies to a script or a stylesheet fetched from another origin. On
+        # every page of web/public it matches lines 8 to 11 - the canonical link
+        # and three hreflang alternates - while the one real stylesheet, at line
+        # 31, it does not match at all. 48 findings, none of them about a
+        # subresource. This site loads nothing from another origin by design.
+        #
+        # Excluded here rather than through a .semgrepignore file, and that is
+        # also from measurement: a .semgrepignore REPLACES semgrep own default
+        # patterns instead of adding to them. Measured 2026-08-27, adding one
+        # took the scan from 217 files to 366 by pulling in all 166 guard test
+        # files, and with them a new blocking finding. Security scanning of test
+        # files is a question this project already answered for gosec, and the
+        # answer was no.
+        run: |
+          semgrep scan --config p/default --metrics=off --oss-only --json --output semgrep.json --quiet --exclude-rule html.security.audit.missing-integrity.missing-integrity
+
+      - name: decide
+        # Separate from the scan on purpose. Measured on the development machine
+        # 2026-08-27: a semgrep whose core failed printed four errors, exited 0,
+        # and wrote a 23 byte file that was not JSON. Reading the exit code would
+        # have called that a clean tree. The gate reads the report.
+        run: python .github/scripts/semgrep_gate.py semgrep.json
+
   touched:
     name: what this push touched
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,55 @@
+# Blocks a pull request that introduces a dependency with a known vulnerability
+# or a licence this project may not distribute.
+#
+# Why a separate workflow and not a job in ci.yml: the action compares the
+# dependency manifests of the BASE and the HEAD of a pull request, so it is
+# meaningful on `pull_request` only. A push has nothing to diff against. Wiring
+# it into the main matrix would make it run, and be skipped, several more times
+# per push for no benefit.
+name: dependency review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  # The summary comment needs this. On a pull request from a fork the token is
+  # read only whatever this says, so the comment is a convenience on our own
+  # branches rather than something a stranger can reach.
+  pull-requests: write
+
+jobs:
+  review:
+    name: review new dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
+        with:
+          # This tool writes files wherever it is pointed and its releases are
+          # built by these same workflows, so a vulnerable dependency has no
+          # business arriving quietly. Anything at or above "moderate" fails the
+          # pull request rather than warning in a log nobody reads.
+          fail-on-severity: moderate
+          comment-summary-in-pr: always
+
+      # The half the action above cannot do. Its own documentation: "If we can't
+      # detect the license for a dependency we will inform you, but the action
+      # won't fail." For a GPL-3.0 project that ships a binary, an unidentified
+      # licence is the one answer nobody can act on, so the same data is read
+      # again here and an unknown licence blocks exactly like a denied one.
+      #
+      # `gh` is preinstalled and uses the job token. The gate exits 2 when it
+      # cannot read the answer, so a refusal from the endpoint fails the run
+      # instead of looking like an empty list of problems.
+      - name: Licences of what this pull request adds
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/$REPO/dependency-graph/compare/$BASE...$HEAD" > deps.json
+          python .github/scripts/dependency_gate.py deps.json

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,14 +33,36 @@ concurrency:
 jobs:
   publish:
     # A dispatch is a person asking on purpose. Everything else has to be CI
-    # saying the tree is good.
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    # saying the tree is good, ON THIS REPOSITORY, for a push.
+    #
+    # The last two conditions were added on 2026-08-27, the day this project
+    # started taking pull requests, and they close a hole that opened with it.
+    # This job runs on workflow_run, which fires in the base repository with the
+    # base repository's permissions - and it holds pages: write. CI runs on
+    # pull_request, and the branches filter above matches the branch NAME of the
+    # run that triggered it, which for a fork is a name the fork chose. A fork
+    # whose branch is called main, opening a pull request that passes CI, would
+    # otherwise reach this job, and this job publishes web/public to the project
+    # website.
+    #
+    # Nothing here executes repository code, so the exposure was defacement
+    # rather than anything reaching a secret. That is still not a thing to leave
+    # open once anyone can open a pull request.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      # The rule below is right about the shape and the condition above is the
+      # answer to it: this job only runs for a push, on this repository, so the
+      # head_sha it checks out cannot come from a fork.
+      # nosemgrep: yaml.github-actions.security.workflow-run-target-code-checkout.workflow-run-target-code-checkout
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           # The commit CI passed on, not whatever main happens to be now. On a

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,7 +41,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           # The commit CI passed on, not whatever main happens to be now. On a
           # dispatch there is no such commit and the default ref is right.
@@ -56,11 +56,11 @@ jobs:
           test -f web/public/sitemap.xml
           test -f web/public/CNAME
 
-      - uses: actions/configure-pages@v6
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
 
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
           path: web/public
 
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,9 @@ jobs:
     env:
       CGO_ENABLED: "0"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -94,9 +94,9 @@ jobs:
       # one place is how it stays visible if it ever stops being true.
       CGO_ENABLED: "0"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -157,7 +157,7 @@ jobs:
 
           ls -l dist
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: cli
           path: dist/*
@@ -192,9 +192,9 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -253,7 +253,7 @@ jobs:
           echo "packaged ${base}"
           ls -l dist
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: gui-${{ matrix.os }}
           path: dist/*
@@ -270,9 +270,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: incoming
           merge-multiple: true

--- a/internal/core/records.go
+++ b/internal/core/records.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	// D11 promises the same bytes from the same seed, so a deliberate,
+	// reproducible generator is the product rather than a weakness. Nothing
+	// here ever makes a secret.
+	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used
 	"math/rand/v2"
 	"unicode/utf8"
 )

--- a/internal/core/seed.go
+++ b/internal/core/seed.go
@@ -3,6 +3,10 @@ package core
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	// D11 promises the same bytes from the same seed, so a deliberate,
+	// reproducible generator is the product rather than a weakness. Nothing
+	// here ever makes a secret.
+	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used
 	"math/rand/v2"
 	"strconv"
 )

--- a/internal/format/csvfile/csv.go
+++ b/internal/format/csvfile/csv.go
@@ -9,6 +9,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	// D11 promises the same bytes from the same seed, so a deliberate,
+	// reproducible generator is the product rather than a weakness. Nothing
+	// here ever makes a secret.
+	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used
 	"math/rand/v2"
 	"strconv"
 

--- a/internal/format/htmlfile/html.go
+++ b/internal/format/htmlfile/html.go
@@ -9,6 +9,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	// D11 promises the same bytes from the same seed, so a deliberate,
+	// reproducible generator is the product rather than a weakness. Nothing
+	// here ever makes a secret.
+	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used
 	"math/rand/v2"
 	"strconv"
 	"strings"

--- a/internal/format/jsonfile/json.go
+++ b/internal/format/jsonfile/json.go
@@ -9,6 +9,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	// D11 promises the same bytes from the same seed, so a deliberate,
+	// reproducible generator is the product rather than a weakness. Nothing
+	// here ever makes a secret.
+	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used
 	"math/rand/v2"
 	"strconv"
 

--- a/internal/format/logfile/log.go
+++ b/internal/format/logfile/log.go
@@ -8,6 +8,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	// D11 promises the same bytes from the same seed, so a deliberate,
+	// reproducible generator is the product rather than a weakness. Nothing
+	// here ever makes a secret.
+	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used
 	"math/rand/v2"
 	"strconv"
 

--- a/internal/format/md/md.go
+++ b/internal/format/md/md.go
@@ -10,6 +10,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	// D11 promises the same bytes from the same seed, so a deliberate,
+	// reproducible generator is the product rather than a weakness. Nothing
+	// here ever makes a secret.
+	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used
 	"math/rand/v2"
 	"strconv"
 	"unicode"

--- a/internal/format/opc/opc.go
+++ b/internal/format/opc/opc.go
@@ -28,6 +28,10 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	// D11 promises the same bytes from the same seed, so a deliberate,
+	// reproducible generator is the product rather than a weakness. Nothing
+	// here ever makes a secret.
+	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used
 	"math/rand/v2"
 	"strings"
 	"time"

--- a/internal/format/svgfile/svg.go
+++ b/internal/format/svgfile/svg.go
@@ -8,6 +8,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	// D11 promises the same bytes from the same seed, so a deliberate,
+	// reproducible generator is the product rather than a weakness. Nothing
+	// here ever makes a secret.
+	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used
 	"math/rand/v2"
 	"strconv"
 

--- a/internal/format/xmlfile/xml.go
+++ b/internal/format/xmlfile/xml.go
@@ -9,6 +9,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	// D11 promises the same bytes from the same seed, so a deliberate,
+	// reproducible generator is the product rather than a weakness. Nothing
+	// here ever makes a secret.
+	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used
 	"math/rand/v2"
 	"strconv"
 

--- a/internal/guard/actionpinning_test.go
+++ b/internal/guard/actionpinning_test.go
@@ -1,0 +1,123 @@
+package guard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Every action a workflow runs is named by commit, never by a tag.
+//
+// A tag is a pointer somebody else can move. `actions/checkout@v7` means "run
+// whatever that account calls v7 at the moment the job starts", and the account
+// is free to repoint it - which is the supply chain question this repository
+// answers nowhere else. A release of this tool is built by these workflows, so
+// an action that changed under us would sign and publish binaries nobody here
+// reviewed.
+//
+// Measured 2026-08-27: a registry rule flagged 32 such uses across the three
+// workflows, and it was the only finding in that scan carrying high confidence.
+// All 32 now carry a commit.
+//
+// The tag is not lost - it moves into a comment beside the commit, so a reader
+// can still tell v7.0.1 from v5.0.0 without resolving anything. Dependabot
+// updates both halves together, which is why the comment is allowed to be the
+// only place a version appears.
+//
+// This walks every file in the directory rather than a list of names, so a
+// workflow added next month is covered without anybody remembering to come
+// back here.
+func TestEveryActionIsPinnedToACommitRatherThanATag(t *testing.T) {
+	dir := filepath.Join(repoRoot(t), ".github", "workflows")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Skipf("the workflows are not here: %v", err)
+	}
+
+	// Asking the predicate about inputs the tree does not currently contain.
+	//
+	// Without this the guard would be unfalsifiable: every action IS pinned
+	// today, so a change that weakened the rule would find nothing to let
+	// through and stay green. These cases keep a hold on the rule itself, and
+	// they do not go away when the tree is clean.
+	for _, c := range []struct {
+		uses   string
+		pinned bool
+		why    string
+	}{
+		{"actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", true, "a full commit"},
+		{"actions/checkout@v7", false, "a moving major tag"},
+		{"actions/checkout@v7.0.1", false, "an exact version is still a tag somebody can move"},
+		{"actions/checkout@main", false, "a branch"},
+		{"actions/checkout@3d3c42e", false, "an abbreviated commit, which is not unique for ever"},
+		{"actions/checkout", false, "no ref at all means the default branch"},
+		{"actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90bZ", false, "the right length but not hexadecimal"},
+	} {
+		if pinnedToACommit(c.uses) != c.pinned {
+			t.Errorf("pinnedToACommit(%q) should be %v, because it is %s", c.uses, c.pinned, c.why)
+		}
+	}
+
+	seen := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || (!strings.HasSuffix(name, ".yml") && !strings.HasSuffix(name, ".yaml")) {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		// Comments are removed first, because the version now lives in one and
+		// "# v7.0.1" would otherwise read as a reference.
+		for i, line := range strings.Split(withoutYamlComments(string(body)), "\n") {
+			_, after, found := strings.Cut(strings.TrimSpace(line), "uses:")
+			if !found {
+				continue
+			}
+			uses := strings.TrimSpace(after)
+			if uses == "" {
+				continue
+			}
+			seen++
+			if pinnedToACommit(uses) {
+				continue
+			}
+			t.Errorf("%s:%d runs %s, which names a tag rather than a commit.\n"+
+				"Whoever owns that action can repoint the tag, and this repository builds "+
+				"its releases here. Resolve the tag to its commit and keep the version in a "+
+				"comment beside it:\n"+
+				"    uses: OWNER/NAME@<40 hex characters>  # v1.2.3",
+				name, i+1, uses)
+		}
+	}
+
+	// A walk that matched nothing would report a clean tree, which is the way
+	// this guard is most likely to break: a rename of the directory, a change
+	// of suffix, a parser that stops seeing "uses:".
+	if seen == 0 {
+		t.Errorf("no action reference was found in %s, so this guard checked nothing.\n"+
+			"Either the workflows moved or the way this reads them stopped working.", dir)
+	}
+}
+
+// pinnedToACommit reports whether a `uses:` value names a commit.
+//
+// Forty hexadecimal characters and nothing else. An abbreviated hash is refused
+// on purpose: git shortens for people, and a prefix that is unique today can
+// stop being unique in a repository that keeps growing.
+func pinnedToACommit(uses string) bool {
+	_, ref, found := strings.Cut(uses, "@")
+	if !found || len(ref) != 40 {
+		return false
+	}
+	for _, r := range ref {
+		digit := r >= '0' && r <= '9'
+		lower := r >= 'a' && r <= 'f'
+		if !digit && !lower {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/guard/dependencygate_test.go
+++ b/internal/guard/dependencygate_test.go
@@ -1,0 +1,181 @@
+package guard
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// pythonForGate finds an interpreter, or says why it could not.
+//
+// The gate is a script rather than Go because it reads an answer `gh` fetches
+// in the same job, and CI runners carry python. Here it may genuinely be
+// missing, and a skip that names the reason beats a guard that quietly passes.
+func pythonForGate(t *testing.T) string {
+	t.Helper()
+	for _, name := range []string{"python", "python3"} {
+		if p, err := exec.LookPath(name); err == nil {
+			return p
+		}
+	}
+	t.Skip("neither python nor python3 is on PATH, so the gate cannot be asked anything")
+	return ""
+}
+
+// gatePath is the one place the script is named, so a move breaks one line.
+func gatePath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(repoRoot(t), ".github", "scripts", "dependency_gate.py")
+}
+
+// runGate writes one dependency review answer and returns the gate's exit code.
+func runGate(t *testing.T, python string, review any) int {
+	t.Helper()
+	body, err := json.Marshal(review)
+	if err != nil {
+		t.Fatalf("building the review: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "deps.json")
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("writing the review: %v", err)
+	}
+	out, err := exec.Command(python, gatePath(t), path).CombinedOutput()
+	if err == nil {
+		return 0
+	}
+	var exit *exec.ExitError
+	if errors.As(err, &exit) {
+		return exit.ExitCode()
+	}
+	t.Fatalf("running the gate: %v\n%s", err, out)
+	return -1
+}
+
+type dep map[string]any
+
+// The gate answers for a licence rather than only for a vulnerability.
+//
+// actions/dependency-review-action fails a pull request that adds a dependency
+// with a known vulnerability and says plainly that it will NOT fail on a licence
+// it could not identify. This project is GPL-3.0 and ships a binary, so "we
+// could not tell" is the one answer nobody can act on, and the gate beside the
+// action exists for exactly that half.
+//
+// Asked here by running it, because a list of allowed identifiers read back by
+// a test would only agree with itself.
+func TestTheDependencyGateRefusesALicenceThisProjectCannotDistribute(t *testing.T) {
+	python := pythonForGate(t)
+
+	for _, c := range []struct {
+		what   string
+		review []dep
+		want   int
+	}{
+		{
+			"a permissive licence we already carry",
+			[]dep{{"change_type": "added", "ecosystem": "gomod",
+				"name": "example.com/fine", "version": "v1.0.0", "license": "MIT"}},
+			0,
+		},
+		{
+			// Measured on this repository 2026-08-27: golang.org/x/sys, x/net
+			// and x/image all report this pair, because the Go project ships a
+			// PATENTS file beside its licence. Three modules already in the tree
+			// would be blocked if the second half were not allowed.
+			"the Go patents grant, which adds rights rather than restricting them",
+			[]dep{{"change_type": "added", "ecosystem": "gomod",
+				"name": "golang.org/x/sys", "version": "v0.47.0",
+				"license": "BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang"}},
+			0,
+		},
+		{
+			"a licence GitHub could not determine, which is the case the action skips",
+			[]dep{{"change_type": "added", "ecosystem": "gomod",
+				"name": "example.com/mystery", "version": "v1.0.0", "license": nil}},
+			1,
+		},
+		{
+			// The one identifier the licence policy names as a blocker rather
+			// than a formality, because it cannot be combined with GPL-3.0.
+			"GPL-2.0-only",
+			[]dep{{"change_type": "added", "ecosystem": "gomod",
+				"name": "example.com/gpl2", "version": "v1.0.0", "license": "GPL-2.0-only"}},
+			1,
+		},
+		{
+			"a compound expression where one half is denied",
+			[]dep{{"change_type": "added", "ecosystem": "gomod",
+				"name": "example.com/half", "version": "v1.0.0", "license": "MIT AND GPL-2.0-only"}},
+			1,
+		},
+		{
+			// An action never reaches a user, so it creates no distribution
+			// obligation. What actions are held to instead is stricter and sits
+			// in TestEveryActionIsPinnedToACommitRatherThanATag.
+			"an action, for which GitHub reports no licence at all",
+			[]dep{{"change_type": "added", "ecosystem": "actions",
+				"name": "actions/checkout", "version": "v7", "license": nil}},
+			0,
+		},
+		{
+			"a dependency being REMOVED, which creates no obligation",
+			[]dep{{"change_type": "removed", "ecosystem": "gomod",
+				"name": "example.com/gpl2", "version": "v1.0.0", "license": "GPL-2.0-only"}},
+			0,
+		},
+	} {
+		if got := runGate(t, python, c.review); got != c.want {
+			t.Errorf("the gate answered %d for %s, and it has to answer %d", got, c.what, c.want)
+		}
+	}
+}
+
+// A gate that cannot read its answer has not passed anything.
+//
+// The dependency graph endpoint refuses some repository shapes, and a 403 has
+// to fail the run rather than look like an empty list of problems. This is the
+// same shape as the semgrep gate beside it, and both were written that way
+// because a scanner that fails can exit zero.
+func TestTheDependencyGateFailsClosedWhenItCannotReadTheAnswer(t *testing.T) {
+	python := pythonForGate(t)
+	missing := filepath.Join(t.TempDir(), "was-never-written.json")
+
+	err := exec.Command(python, gatePath(t), missing).Run()
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) {
+		t.Fatalf("the gate accepted an answer that does not exist, err=%v", err)
+	}
+	if exit.ExitCode() != 2 {
+		t.Errorf("an unreadable answer exits %d, and it has to exit 2.\n"+
+			"Exit 1 would read as 'found problems' and exit 0 as 'there were none', "+
+			"and neither is true when the gate never saw the data.", exit.ExitCode())
+	}
+}
+
+// CI has to actually ask the gate, on the event where the question exists.
+//
+// The action compares the base and the head of a pull request, so it is
+// meaningful on pull_request only. A gate nothing runs is a file, not a gate.
+func TestCIAsksTheDependencyGateOnEveryPullRequest(t *testing.T) {
+	path := filepath.Join(repoRoot(t), ".github", "workflows", "dependency-review.yml")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading the dependency review workflow: %v", err)
+	}
+	text := withoutYamlComments(string(body))
+
+	for _, want := range []struct{ needle, why string }{
+		{"pull_request", "the manifests of a base and a head only exist on a pull request"},
+		{"dependency-review-action", "the vulnerability half comes from the action"},
+		{".github/scripts/dependency_gate.py", "the licence half comes from the gate beside it"},
+		{"fail-on-severity: moderate", "anything at or above moderate has to fail rather than warn"},
+	} {
+		if !strings.Contains(text, want.needle) {
+			t.Errorf("the dependency review workflow never mentions %q, and %s", want.needle, want.why)
+		}
+	}
+}

--- a/internal/guard/publishcondition_test.go
+++ b/internal/guard/publishcondition_test.go
@@ -1,0 +1,65 @@
+package guard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Publishing the website happens for a push to this repository, and nothing else.
+//
+// The job that deploys web/public triggers on workflow_run. That event fires in
+// the BASE repository, with the base repository's permissions, and this job
+// holds pages: write. CI runs on pull_request, and the branches filter on
+// workflow_run matches the branch NAME of the run that triggered it - which for
+// a pull request from a fork is a name the fork chose. A fork whose branch was
+// called main, opening a pull request that passed CI, would otherwise satisfy
+// every condition this job had before 2026-08-27.
+//
+// Nothing in the job executes repository code. It checks three files exist and
+// uploads a directory, so what was reachable was the content of the published
+// site rather than a secret. That is defacement of the project website, which is
+// worth a condition.
+//
+// Read as text rather than by parsing the expression, because what matters is
+// that both questions are asked at all. A YAML parser would hand back one
+// string and this would still have to look inside it.
+func TestTheSiteIsPublishedOnlyForAPushToThisRepository(t *testing.T) {
+	path := filepath.Join(repoRoot(t), ".github", "workflows", "pages.yml")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("the publishing workflow is not here: %v", err)
+	}
+	text := withoutYamlComments(string(body))
+
+	// The trigger this is all about. If it ever stops being workflow_run the
+	// conditions below are answering a question nobody asked any more, and this
+	// guard should be revisited rather than quietly kept passing.
+	if !strings.Contains(text, "workflow_run:") {
+		t.Fatalf("pages.yml no longer triggers on workflow_run, so this guard is " +
+			"defending a shape that is gone. Read it again before deleting it.")
+	}
+
+	for _, want := range []struct{ needle, why string }{
+		{
+			"head_repository.full_name == github.repository",
+			"without it a fork's pull request run can reach a job that publishes the website",
+		},
+		{
+			"workflow_run.event == 'push'",
+			"a run triggered by a pull request must never publish, whoever opened it",
+		},
+		{
+			"workflow_run.conclusion == 'success'",
+			"a red suite means the site does not move, which is why this job waits for CI at all",
+		},
+	} {
+		if !strings.Contains(text, want.needle) {
+			t.Errorf("the publish job does not ask for %q.\n"+
+				"That condition is there because %s.\n"+
+				"This job runs with the base repository's permissions and holds pages: write.",
+				want.needle, want.why)
+		}
+	}
+}

--- a/internal/guard/semgrepgate_test.go
+++ b/internal/guard/semgrepgate_test.go
@@ -1,0 +1,160 @@
+package guard
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// semgrepGatePath is the one place the script is named.
+func semgrepGatePath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(repoRoot(t), ".github", "scripts", "semgrep_gate.py")
+}
+
+// runSemgrepGate writes one report and returns the gate's exit code.
+func runSemgrepGate(t *testing.T, python string, report any) int {
+	t.Helper()
+	body, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("building the report: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "semgrep.json")
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("writing the report: %v", err)
+	}
+	out, err := exec.Command(python, semgrepGatePath(t), path).CombinedOutput()
+	if err == nil {
+		return 0
+	}
+	var exit *exec.ExitError
+	if errors.As(err, &exit) {
+		return exit.ExitCode()
+	}
+	t.Fatalf("running the gate: %v\n%s", err, out)
+	return -1
+}
+
+// scanned is the shape of a report that did look at something.
+func scanned(results []any, errs []any) map[string]any {
+	return map[string]any{
+		"results": results,
+		"errors":  errs,
+		"paths":   map[string]any{"scanned": []string{"a.go", "b.go"}},
+	}
+}
+
+func finding(severity string) any {
+	return map[string]any{
+		"check_id": "some.rule",
+		"path":     "a.go",
+		"start":    map[string]any{"line": 1},
+		"extra":    map[string]any{"severity": severity, "message": "something"},
+	}
+}
+
+// The gate blocks on the severities the scanner's own flag cannot express.
+//
+// `semgrep --severity` accepts INFO, WARNING and ERROR only, while rules from
+// the registry also carry HIGH and CRITICAL. A gate built on that flag would
+// quietly ignore exactly the severities it was asked to block, which is why the
+// decision is made from the report here instead.
+func TestTheSemgrepGateBlocksTheSeveritiesTheFlagCannotExpress(t *testing.T) {
+	python := pythonForGate(t)
+
+	for _, c := range []struct {
+		severity string
+		want     int
+	}{
+		{"ERROR", 1},
+		{"HIGH", 1},
+		{"CRITICAL", 1},
+		{"WARNING", 0},
+		{"INFO", 0},
+	} {
+		got := runSemgrepGate(t, python, scanned([]any{finding(c.severity)}, nil))
+		if got != c.want {
+			t.Errorf("a %s finding made the gate exit %d, and it has to exit %d",
+				c.severity, got, c.want)
+		}
+	}
+}
+
+// A rule that could not run is not a rule that found nothing.
+//
+// Only an entry at level "error" counts. Measured on this repository: a healthy
+// run still carries entries at level "warn", all of them semgrep declining to
+// parse a shell snippet inside a workflow, and stopping on those would make the
+// gate fire on every run.
+func TestASemgrepScanErrorIsNotACleanScan(t *testing.T) {
+	python := pythonForGate(t)
+
+	fatal := map[string]any{"level": "error", "type": "SemgrepError", "message": "a rule failed"}
+	if got := runSemgrepGate(t, python, scanned(nil, []any{fatal})); got != 1 {
+		t.Errorf("a scan error exited %d, and it has to exit 1.\n"+
+			"'the scan was green' must never be able to mean 'the scan did not happen'.", got)
+	}
+
+	noisy := map[string]any{"level": "warn", "type": "PartialParsing", "message": "a snippet"}
+	if got := runSemgrepGate(t, python, scanned(nil, []any{noisy})); got != 0 {
+		t.Errorf("a warning-level scan entry exited %d, and it has to exit 0.\n"+
+			"This repository produces those on every healthy run.", got)
+	}
+}
+
+// A scanner that fails can succeed, so the report is the answer.
+//
+// Measured on the development machine 2026-08-27, semgrep 1.175.0 on Windows:
+// the scan failed its own rule validation, printed four RPC errors, EXITED 0,
+// and wrote 23 bytes that were not JSON. A gate reading the exit code would
+// have called that a clean tree.
+//
+// The second case is the quiet one. A wrong working directory writes a valid
+// report with an empty result list, and every reader downstream would call that
+// a pass.
+func TestTheSemgrepGateFailsClosedWhenTheScanDidNotHappen(t *testing.T) {
+	python := pythonForGate(t)
+
+	missing := filepath.Join(t.TempDir(), "was-never-written.json")
+	err := exec.Command(python, semgrepGatePath(t), missing).Run()
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) {
+		t.Fatalf("the gate accepted a report that does not exist, err=%v", err)
+	}
+	if exit.ExitCode() != 2 {
+		t.Errorf("an unreadable report exited %d, and it has to exit 2", exit.ExitCode())
+	}
+
+	nothingRead := map[string]any{
+		"results": []any{}, "errors": []any{},
+		"paths": map[string]any{"scanned": []string{}},
+	}
+	if got := runSemgrepGate(t, python, nothingRead); got != 2 {
+		t.Errorf("a report saying no file was scanned exited %d, and it has to exit 2.\n"+
+			"An empty result list from a scan that read nothing is not a clean tree.", got)
+	}
+}
+
+// CI has to run the scanner and decide from what it wrote.
+func TestCIRunsSemgrepAndDecidesFromTheReportRatherThanTheExitCode(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join(repoRoot(t), ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("reading ci.yml: %v", err)
+	}
+	text := withoutYamlComments(string(body))
+
+	for _, want := range []struct{ needle, why string }{
+		{"semgrep==", "an unpinned analyser turns somebody else's release into a red build"},
+		{"--config p/default", "the rules come from the registry rather than from this repository"},
+		{"--metrics=off", "this repository sends no telemetry about its own source"},
+		{".github/scripts/semgrep_gate.py", "the report is what decides, not the scanner's exit code"},
+	} {
+		if !strings.Contains(text, want.needle) {
+			t.Errorf("the semgrep job never mentions %q, and %s", want.needle, want.why)
+		}
+	}
+}

--- a/internal/gui/text/catalogue.go
+++ b/internal/gui/text/catalogue.go
@@ -6,6 +6,9 @@ import (
 	"io/fs"
 	"path"
 	"strings"
+	// Window labels and tooltips, which are never HTML. The rule is about
+	// rendering user content into a page, and this package renders neither.
+	// nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 	"text/template"
 
 	"github.com/nicksnyder/go-i18n/v2/i18n"

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -59,6 +59,7 @@ func (c Checker) Check(path string) Result {
 	// package and the path from a run this tool just produced, neither of
 	// them from anything a user typed.
 	//nolint:gosec // the command is ours and the path is one we just wrote
+	// nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
 	cmd := exec.CommandContext(ctx, bin, c.args(path)...)
 	var out, errOut strings.Builder
 	cmd.Stdout = &out
@@ -327,6 +328,7 @@ func Strict(formatID, path string) Result {
 
 	//nolint:gosec // same as above - our own script, run against a file this
 	// tool wrote a moment ago
+	// nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
 	cmd := exec.CommandContext(ctx, python, script, formatID, path)
 	var out, errOut strings.Builder
 	cmd.Stdout = &out

--- a/internal/recipe/keys.go
+++ b/internal/recipe/keys.go
@@ -17,6 +17,10 @@ import (
 // contain and the refusal is what makes them visible. What this build does with
 // a key is a different question from whether the key exists.
 func Keys() []string {
+	// collect fills this map through the call below, which the rule does not
+	// follow, so it reads the map as one nothing ever writes to. An empty one
+	// would redden the two guards that read Keys.
+	// nosemgrep: trailofbits.go.iterate-over-empty-map.iterate-over-empty-map
 	seen := map[string]bool{}
 	collect(reflect.TypeOf(rawRecipe{}), "", seen)
 	out := make([]string, 0, len(seen))

--- a/internal/site/render.go
+++ b/internal/site/render.go
@@ -201,6 +201,7 @@ func (s Site) notFound(partials, shell string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	// nosemgrep: go.lang.security.audit.xss.template-html-does-not-escape.unsafe-template-type
 	v.Body = template.HTML(rendered) //nolint:gosec // built from the word list above
 	whole, err := run("page:404", partials+shell, v)
 	if err != nil {
@@ -230,6 +231,7 @@ func (s Site) renderPages(out map[string][]byte, partials, shell string) error {
 			if err != nil {
 				return err
 			}
+			// nosemgrep: go.lang.security.audit.xss.template-html-does-not-escape.unsafe-template-type
 			v.Body = template.HTML(body) //nolint:gosec // our own content files, rendered by us
 
 			whole, err := run("page:"+lang.Code+":"+page.Key, partials+shell, v)

--- a/internal/site/view.go
+++ b/internal/site/view.go
@@ -16,6 +16,10 @@ import (
 	"strconv"
 	"strings"
 
+	// Deliberate, and the reason is on expand below: these values are put
+	// into pages as text and escaped there by html/template. Escaping them
+	// twice would show a reader the escape instead of the character.
+	// nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 	texttemplate "text/template"
 )
 


### PR DESCRIPTION
Two supply chain gates, every action pinned to a commit, and the 98 findings from
the first semgrep scan brought to zero.

## What blocks now

**Dependency review**, on pull requests only, because the action compares the
manifests of a base and a head and a push has nothing to diff against. The action
fails a pull request that adds a dependency with a known vulnerability. Its own
documentation says it will not fail on a licence it could not identify, and for a
GPL-3.0 project that ships a binary that is the one answer nobody can act on - so
a gate beside it reads the same data and blocks an unknown licence like a denied
one.

**Semgrep**, in the main workflow, deciding from its report rather than from its
exit code.

Both gates exit 2 when they cannot read their input, and neither can be made to
report a clean tree by failing.

## Why the gates read a report instead of an exit code

Measured on the development machine, semgrep 1.175.0 on Windows: the scan failed
its own rule validation, printed four RPC errors, **exited 0**, and wrote 23 bytes
containing `<ERROR: missing output>` instead of JSON. A gate reading that exit
code would have reported a clean tree. The gate read the file, failed to parse it,
and exited 2.

The same gate also refuses a report saying no file was scanned. That is the quiet
version of the same failure: a wrong working directory writes a perfectly valid
report with an empty result list, and every reader downstream would call it a pass.

## Actions

All 32 uses across the three workflows moved from `@v5`, `@v6`, `@v7` and `@v8` to
commits, with the version kept in a comment beside each. A tag is a pointer the
owning account can repoint, and these workflows build and publish the releases.
Every SHA was resolved from the API rather than recalled.

The guard walks the workflow directory rather than a list of names, so the new
workflow in this change was covered without being told about it. It also asks its
rule about references the tree does not contain - a tag, a branch, an abbreviated
hash, forty non-hex characters - because everything is pinned today, and a
weakened rule would otherwise find nothing to let through and stay green.

## Findings: 98 to 0

33 fixed, 65 recorded as a decision at the line. A `nosemgrep` comment rather than
a list inside the gate, because the same report is also read on semgrep.dev, and a
decision only half the readers can see is hidden rather than recorded.

What was settled, each with its reason beside it:

- `math/rand/v2` in ten files is what the byte stability promise requires, not a
  weakness. Nothing there ever makes a secret.
- Two `exec` sites are in a package the compiler proves is linked into neither
  binary.
- `text/template` feeds values that `html/template` escapes one level up, which
  the code already said before any scanner asked.

One rule is excluded in the scan command instead. `missing-integrity` asks for a
subresource integrity attribute and matches the canonical and hreflang links on
lines 8 to 11 of every page, while missing the one real stylesheet at line 31.
48 findings, none of them about a subresource, on a site that loads nothing from
another origin by design.

It is excluded there rather than through a `.semgrepignore`, and that is from
measurement: a `.semgrepignore` **replaces** semgrep's own default patterns rather
than adding to them. Adding one took the scan from 217 files to 366 by pulling in
all 166 guard test files, and with them a new blocking finding. Whether to scan
test files for security is a question this project already answered for gosec.

## Security fix found on the way

The site publishing job now refuses a run that did not come from a push to this
repository.

It triggers on `workflow_run`, which fires in the base repository with the base
repository's permissions, and it holds `pages: write`. CI runs on `pull_request`,
and the branch filter on `workflow_run` matches the branch NAME of the triggering
run - which for a fork is a name the fork chose. A fork whose branch was called
`main`, opening a pull request that passed CI, could otherwise have reached the job
that publishes the site.

Nothing in that job executes repository code, so the exposure was defacement rather
than anything reaching a secret. That is still not a thing to leave open on the day
a project starts taking pull requests.

## Guards

Nine new guards, every one proven by mutation before being counted. The gates are
asked by running them, on the cases that matter, because a list of allowed
identifiers read back by a test would only agree with itself.

## After merge

The two new checks do not block a merge until their context names are added to the
branch ruleset: `review new dependencies` and `semgrep`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
