### PR TITLE
One CI run per change, and the race detector asks about the right commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,17 @@
 name: CI
 
 on:
+  # Only main, because every other branch reaches this through a pull request
+  # and would otherwise run the whole suite twice for one change. Measured on
+  # pull request 4, the first one this project had: every job appeared twice,
+  # once for the branch push and once for the pull request, and the race
+  # detector ran both times at about ten minutes each.
+  #
+  # The cost of the narrower trigger is that pushing a branch with no pull
+  # request open gives no signal. Since 2026-08-27 main only takes pull
+  # requests, so that state is a step on the way rather than a place work sits.
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
   schedule:
@@ -461,7 +471,15 @@ jobs:
         run: |
           set -euo pipefail
           watched='internal/format/registry.go cmd/tfg/main.go internal/gui/window/run.go go.mod'
-          before="${{ github.event.before }}"
+          # On a pull request there is no "before" - the field belongs to a push
+          # - so this asked for something empty and every pull request answered
+          # "touched". That quietly undid the decision of 2026-08-20, because
+          # from the day this project started taking pull requests the detector
+          # was back to running on everything. The base of the pull request is
+          # the commit to compare against, and github.sha is the merge commit,
+          # so the difference between them is exactly what the pull request
+          # changes.
+          before="${{ github.event.pull_request.base.sha || github.event.before }}"
           if [ -z "$before" ] \
             || [ "$before" = "0000000000000000000000000000000000000000" ] \
             || ! git cat-file -e "${before}^{commit}" 2>/dev/null

--- a/internal/guard/onerun_test.go
+++ b/internal/guard/onerun_test.go
@@ -1,0 +1,95 @@
+package guard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ciHeader is everything above the jobs, with comments removed.
+//
+// Scoped rather than searched whole, because a trigger is a claim about when
+// the suite runs and a match anywhere else in a six hundred line file would
+// satisfy a careless assertion without meaning anything.
+func ciHeader(t *testing.T) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(repoRoot(t), ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("reading ci.yml: %v", err)
+	}
+	text := withoutYamlComments(string(body))
+	head, _, found := strings.Cut(text, "\njobs:")
+	if !found {
+		t.Fatalf("ci.yml has no jobs block, so this guard cannot tell a trigger from a job")
+	}
+	return head
+}
+
+// The suite runs once for one change.
+//
+// Measured on pull request 4, the first this project had: every job appeared
+// twice, once for the branch push and once for the pull request event, and the
+// race detector ran on both at about ten minutes each. An unfiltered `push:`
+// means every branch push runs the whole suite, and every branch here now
+// reaches main through a pull request, which runs it again.
+//
+// The pull request trigger is asserted alongside, because removing that instead
+// would also stop the doubling and would be much worse: a pull request from a
+// fork would never be checked at all, and the contexts the branch ruleset
+// requires would never report.
+func TestTheSuiteRunsOncePerChange(t *testing.T) {
+	head := ciHeader(t)
+
+	if !strings.Contains(head, "branches: [main]") {
+		t.Error("ci.yml runs on every push to every branch.\n" +
+			"With work reaching main through pull requests, that runs the whole suite " +
+			"twice for one change - measured on pull request 4, including the race " +
+			"detector at about ten minutes a time.\n" +
+			"Limit the push trigger: `push:` with `branches: [main]` under it.")
+	}
+	if !strings.Contains(head, "pull_request:") {
+		t.Error("ci.yml no longer runs on pull_request.\n" +
+			"That is not a way to stop the suite running twice. A pull request from a " +
+			"fork would go unchecked, and the contexts the branch ruleset requires " +
+			"would never report, so nothing could be merged.")
+	}
+}
+
+// The race detector is asked about the right pair of commits.
+//
+// It runs when one of the three files concurrency lives in has changed, decided
+// on 2026-08-20 after it measured 10m31s against about a minute for the rest.
+// The comparison used `github.event.before`, which belongs to a push and is
+// empty on a pull request - so from the day this project started taking pull
+// requests, every one of them answered "touched" and the detector was back to
+// running on everything. The decision was undone by a change somewhere else,
+// which is the failure this project keeps meeting.
+//
+// On a pull request the commit to compare against is the base, and github.sha
+// is the merge commit, so the difference between them is what the pull request
+// changes.
+func TestTheRaceDetectorAsksAboutWhatThePullRequestChanges(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join(repoRoot(t), ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("reading ci.yml: %v", err)
+	}
+	text := withoutYamlComments(string(body))
+
+	if !strings.Contains(text, "github.event.pull_request.base.sha") {
+		t.Error("the job deciding whether the race detector runs never looks at the " +
+			"pull request's base.\n" +
+			"github.event.before belongs to a push and is empty on a pull request, so " +
+			"the comparison falls through to 'anything unclear counts as touched' and " +
+			"the detector runs on every pull request - which is the thing 2026-08-20 " +
+			"decided it should stop doing.")
+	}
+
+	// The fallback has to survive too. A push to main has no pull request, and
+	// dropping `before` would send every push down the unclear branch instead -
+	// the same defect facing the other way.
+	if !strings.Contains(text, "github.event.before") {
+		t.Error("the comparison no longer falls back to github.event.before, so a push " +
+			"to main has nothing to compare against and counts as touched every time.")
+	}
+}


### PR DESCRIPTION
Two defects with one cause: the trigger set was written for a project that pushed
straight to main, and this one stopped doing that on 2026-08-27.

## The suite ran twice for one change

An unfiltered `push:` trigger runs the whole suite on every branch push, and the
pull request carrying that branch runs it again. Measured on pull request 4, the
first this project had: every job appeared twice, from two separate runs.

`push:` is now limited to `main`. The cost is that pushing a branch with no pull
request open gives no signal, which is a step on the way rather than a place work
sits now that main only takes pull requests.

## The quieter half, which was worse

The job that decides whether the race detector runs compared against
`github.event.before`. That field belongs to a push and is **empty on a pull
request**. The job treats anything unclear as touched - correctly, because the
cost of running the detector needlessly is ten minutes and the cost of skipping
it wrongly is a data race in somebody else's file - so every pull request
answered "touched".

From the day this project started taking pull requests, the ten minute job was
back on everything. Measured on pull request 4: `race detector` was in progress
on **both** runs. The decision of 2026-08-20, taken after that job measured
10m31s against about a minute for the rest of the suite, had been undone by a
change in an entirely different place.

It now compares against the pull request's base. `github.sha` is the merge
commit, so the difference between them is exactly what the pull request changes.

## Guards

Two, three mutations, all proven red before being counted.

One of them holds the `pull_request` trigger as well as the branch filter.
Removing that trigger would also stop the doubling, and would be much worse: a
fork's pull request would go unchecked, and the ten contexts the branch ruleset
now requires would never report, so nothing could be merged at all. Both halves
have their own mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
