### PR TITLE
Issue forms, a security policy, a code of conduct and an owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,29 @@
+# Who owns this repository, and who GitHub asks to review a change to it.
+#
+# One owner, one line. Finer-grained rules would be fiction here: every path
+# below has the same owner, and a list that pretends otherwise ages into a claim
+# nobody checks.
+#
+# What this file DOES do
+# ----------------------
+# A pull request opened by anyone else automatically requests a review from the
+# owner. That is the whole reason it exists: an outside contribution should not
+# sit unnoticed because nobody was asked.
+#
+# What it does NOT do
+# -------------------
+# GitHub never requests a review from the person who opened the pull request, and
+# nobody can approve their own. So on a change written by the owner this file is
+# silent by design - and a branch rule that demands a code-owner approval would,
+# on such a change, demand one from somebody who does not exist. That combination
+# freezes the repository: no pull request can ever be merged.
+#
+# This project therefore protects the default branch with STATUS CHECKS rather
+# than with reviews. Measured on 2026-08-27, the ruleset on the default branch
+# requires ten checks to pass and zero approvals, and `require_code_owner_review`
+# is off. A gate that runs is worth more here than an approval nobody can give.
+#
+# Syntax note: gitignore-style patterns, with three exceptions - a pattern may not
+# start with `#`, `!` does not negate, and `[ ]` character ranges do not work.
+
+*       @donislawdev

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: Bug report
+description: Something in Testing Files Generator does not work as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this. The version, the exact command
+        and the exit code are the three most useful things you can give us.
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `tfg version`.
+      placeholder: "0.1.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      description: This tool promises the same bytes everywhere, so which system you are on is part of the report.
+      options:
+        - Windows
+        - Linux
+        - macOS
+    validations:
+      required: true
+  - type: dropdown
+    id: arch
+    attributes:
+      label: Processor architecture
+      description: >-
+        Releases ship for both. It matters here because this tool promises the
+        same bytes on every machine, and the one measured difference between
+        these two was a rendering difference on arm64.
+      options:
+        - amd64 (Intel or AMD)
+        - arm64 (Apple silicon, ARM)
+        - Not sure
+  - type: dropdown
+    id: surface
+    attributes:
+      label: How were you running it?
+      options:
+        - Command line (tfg)
+        - Window (tfg-gui)
+    validations:
+      required: true
+  - type: input
+    id: format
+    attributes:
+      label: Which format, if it is about one
+      description: The identifier `tfg formats` prints, for example png or targz.
+      placeholder: "pdf"
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: What you expected, and what happened instead.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: The command, or the recipe
+      description: >-
+        The smallest thing that triggers it. A single `tfg` command line is ideal.
+        If it takes a recipe, paste the recipe rather than describing it.
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: exit
+    attributes:
+      label: Exit code
+      description: >-
+        What `echo $?` printed after the command, or `echo %ERRORLEVEL%` on Windows.
+        The codes are a frozen part of this tool's contract, so a wrong one is a
+        bug on its own even when the files came out right.
+      placeholder: "4"
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: >-
+        The manifest, a screenshot of the window, or the output of `tfg verify`.
+        Before attaching a manifest: it records the directory the run wrote to and
+        the name of every file in it, and on most machines that path contains your
+        user name. This issue is public, so read it first and remove anything you
+        would rather not publish.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+# Problems belong here, on the issue tracker, where anyone hitting the same thing
+# can find the answer. There is deliberately no link out to a support page: the
+# only other channel is for vulnerabilities, which must not be public until there
+# is a fix.
+#
+# Blank issues are off because every template below asks for the two or three
+# things that make a report answerable - the version, the system, and the command.
+# A question that fits none of them still has a home: "Question or problem".
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/donislawdev/TestingFilesGenerator/security/advisories/new
+    about: Please report security issues privately, never as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Suggest an improvement or a new capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: The testing situation that is awkward today.
+    validations:
+      required: true
+  - type: textarea
+    id: idea
+    attributes:
+      label: Proposed solution
+      description: What you would like the tool to do.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you have considered
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      description: >-
+        Two things this project has decided and will not revisit without a new
+        argument. Saying so here saves you writing a proposal that was never going
+        to be accepted.
+      options:
+        - label: This works entirely on the local machine. The tool makes no network connections of any kind, and no cloud or remote storage integration is in scope.
+          required: true
+        - label: This belongs in both the command line and the window, not in one of them. Every capability lives in the engine and appears on both surfaces.
+          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,42 @@
+name: Question or problem
+description: Ask about using the tool, or report something that does not fit the other two
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Questions belong here rather than in private mail, because the next person
+        to hit the same thing can find the answer.
+
+        If it turns out to be a defect we will relabel it - you do not have to
+        decide that first.
+  - type: textarea
+    id: question
+    attributes:
+      label: What are you trying to do?
+      description: The testing situation, and what you have tried so far.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `tfg version`, if the tool is already installed.
+      placeholder: "0.1.0"
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows
+        - Linux
+        - macOS
+        - Not relevant
+  - type: textarea
+    id: extra
+    attributes:
+      label: The command, if there is one
+      description: >-
+        Paste it rather than describing it. Anything you paste is public, so
+        check a path for your user name before it goes in.
+      render: shell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,17 @@
 name: CI
 
 on:
+  # Only main, because every other branch reaches this through a pull request
+  # and would otherwise run the whole suite twice for one change. Measured on
+  # pull request 4, the first one this project had: every job appeared twice,
+  # once for the branch push and once for the pull request, and the race
+  # detector ran both times at about ten minutes each.
+  #
+  # The cost of the narrower trigger is that pushing a branch with no pull
+  # request open gives no signal. Since 2026-08-27 main only takes pull
+  # requests, so that state is a step on the way rather than a place work sits.
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
   schedule:
@@ -461,7 +471,15 @@ jobs:
         run: |
           set -euo pipefail
           watched='internal/format/registry.go cmd/tfg/main.go internal/gui/window/run.go go.mod'
-          before="${{ github.event.before }}"
+          # On a pull request there is no "before" - the field belongs to a push
+          # - so this asked for something empty and every pull request answered
+          # "touched". That quietly undid the decision of 2026-08-20, because
+          # from the day this project started taking pull requests the detector
+          # was back to running on everything. The base of the pull request is
+          # the commit to compare against, and github.sha is the merge commit,
+          # so the difference between them is exactly what the pull request
+          # changes.
+          before="${{ github.event.pull_request.base.sha || github.event.before }}"
           if [ -z "$before" ] \
             || [ "$before" = "0000000000000000000000000000000000000000" ] \
             || ! git cat-file -e "${before}^{commit}" 2>/dev/null

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,12 +11,13 @@ name: dependency review
 on:
   pull_request:
 
+# Read only, and nothing here asks for more. The action can post a summary
+# comment on the pull request, which would need `pull-requests: write` - that is
+# deliberately not granted. A failing gate already says everything the comment
+# would: the check goes red and the log names the dependency. A write scope kept
+# for a convenience is a write scope a later job inherits.
 permissions:
   contents: read
-  # The summary comment needs this. On a pull request from a fork the token is
-  # read only whatever this says, so the comment is a convenience on our own
-  # branches rather than something a stranger can reach.
-  pull-requests: write
 
 jobs:
   review:
@@ -33,7 +34,6 @@ jobs:
           # business arriving quietly. Anything at or above "moderate" fails the
           # pull request rather than warning in a log nobody reads.
           fail-on-severity: moderate
-          comment-summary-in-pr: always
 
       # The half the action above cannot do. Its own documentation: "If we can't
       # detect the license for a dependency we will inform you, but the action

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,129 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement through the
+project's contact page at https://donislawdev.com/. All complaints will be
+reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla coc]: https://github.com/mozilla/diversity

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,103 @@
+# Security Policy
+
+## Supported versions
+
+Testing Files Generator has a single line of development. Security fixes are made
+against the **latest release** and the `main` branch. Please confirm you can
+reproduce a problem on the latest version before reporting it.
+
+**Older releases receive nothing.** When a new version is published, the one before
+it stops being supported that day: no security updates, no backports, no patched
+builds. The supported version is whichever release is currently the latest, for as
+long as it is the latest. There is no long-term support line and none is planned,
+so the upgrade path for a security fix is always to move to the newest release.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Use GitHub's private vulnerability reporting: open the
+[Security tab](https://github.com/donislawdev/TestingFilesGenerator/security/advisories/new)
+of this repository and choose **Report a vulnerability**. That keeps the report
+private until a fix is available.
+
+Please include:
+
+- the version (`tfg version`) and your operating system,
+- whether you used the command line (`tfg`) or the window (`tfg-gui`),
+- a clear description and the smallest steps to reproduce, ideally one command
+  line or one recipe,
+- the impact you believe it has.
+
+You can expect an initial response within 14 days or fewer. Once a fix is ready it
+ships in the next release, and the advisory is published crediting the reporter
+unless you prefer to stay anonymous.
+
+## What this tool does, and what that means for scope
+
+Testing Files Generator writes files. That is the whole product, so a report has to
+be about it writing something other than what it was asked to.
+
+**It makes no network connections of any kind.** No telemetry, no update check, no
+cloud client, nothing downloaded while it runs. Measured rather than promised: the
+command line binary does not link a network package at all. The window binary links
+one because the graphical toolkit imports it, and nothing in this project calls it -
+a guard refuses a network import inside our own window code, and the `Donate` button
+hands a link to your browser rather than fetching anything.
+
+**It never deletes anything it was not told about.** `tfg cleanup` removes exactly
+the files a manifest lists and nothing else.
+
+**It writes only inside the output directory.** A file name is a name rather than a
+path, and the manifest name too. Paths that would leave the directory, including
+through a symbolic link, are refused.
+
+**The released binaries are not signed.** Signing is not set up, the release notes
+say so, and your operating system will warn you. Verify a download against
+`SHA256SUMS.txt` from the same release.
+
+### In scope
+
+- A way to make the tool write or delete outside the directory it was given.
+- A recipe or a manifest that makes it do something other than what it says.
+- A crash that corrupts files that were already on disk.
+- A way to make `verify` report a file as good when it does not match the manifest.
+
+### Not in scope
+
+- **The content of the files it generates.** Producing a file that some scanner
+  dislikes is the purpose of a test file generator, not a vulnerability.
+- **Filling a disk when asked to.** The tool refuses a run larger than the free
+  space it can see, but a run that fits and then fills the disk did what you asked.
+- **A file name your operating system will not store.** That is reported as a
+  refusal, on purpose, and is a documented difference between systems.
+
+## Secrets and permissions in this repository
+
+**There are no repository secrets.** Measured on 2026-08-27: zero. Every workflow
+runs on the per-job token GitHub issues for the run, and nothing else is stored
+here.
+
+**Access is scoped per workflow.** The main suite, the dependency review and the
+release workflow all declare `contents: read` at the top, and the single job that
+publishes a release raises `contents: write` on itself. The dependency review
+could post a summary comment on a pull request, which would need
+`pull-requests: write` - that scope is deliberately not granted, because a failing
+check already says what the comment would.
+
+The one workflow holding more is the one that publishes the website: `pages: write`
+and `id-token: write`. It has a single job, and it runs only for a push to this
+repository - a condition added on 2026-08-27 and held by a guard, because the event
+it triggers on fires with this repository's permissions.
+
+**Every action is pinned to a commit** rather than to a tag somebody else can
+repoint, and a guard refuses any workflow that names one another way.
+
+**Dependencies are checked on every pull request**, for known vulnerabilities and
+for licences. A licence GitHub cannot identify blocks the pull request, because for
+a GPL-3.0 project that ships a binary an unidentified licence is the one answer
+nobody can act on.
+
+## Code of conduct
+
+Behaviour in this repository is covered by [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).

--- a/internal/guard/community_test.go
+++ b/internal/guard/community_test.go
@@ -1,0 +1,213 @@
+package guard
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+)
+
+// ourRepository is how a link to this project has to read.
+const ourRepository = "donislawdev/TestingFilesGenerator"
+
+// githubProject matches a link to a repository, and only a link.
+//
+// Anchored on https:// on purpose. The workflows are full of module paths that
+// begin github.com/ and are not links to anything - golangci-lint, staticcheck,
+// every indirect dependency - and a rule that matched those would have to name
+// exceptions for them for ever.
+var githubProject = regexp.MustCompile(`https://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)`)
+
+// Nothing that tells a person where to go points at a different project.
+//
+// These files were brought over from a sibling repository of the same author,
+// and the shape of that mistake is specific: a link that still names the other
+// project reads perfectly, and the worst of them - the private reporting link in
+// the issue chooser - would send somebody's vulnerability report to a repository
+// that is not this one.
+//
+// CODE_OF_CONDUCT.md is not read here, and that is deliberate rather than an
+// oversight. It is the Contributor Covenant carried verbatim, and its closing
+// attribution links to github.com/mozilla/diversity - somebody else's text
+// pointing at somebody else's repository, which is correct and must stay.
+func TestNothingThatDirectsAPersonPointsAtAnotherProject(t *testing.T) {
+	root := repoRoot(t)
+
+	var files []string
+	err := filepath.WalkDir(filepath.Join(root, ".github"), func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			files = append(files, p)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking .github: %v", err)
+	}
+	files = append(files, filepath.Join(root, "SECURITY.md"))
+
+	checked := 0
+	for _, p := range files {
+		body, err := os.ReadFile(p)
+		if err != nil {
+			t.Errorf("reading %s: %v", p, err)
+			continue
+		}
+		for _, m := range githubProject.FindAllStringSubmatch(string(body), -1) {
+			checked++
+			if m[1] == ourRepository {
+				continue
+			}
+			t.Errorf("%s links to https://github.com/%s.\n"+
+				"This project is %s. A link left pointing at another repository is the "+
+				"specific way these files go wrong, and in the issue chooser it would "+
+				"send a vulnerability report to somebody else.",
+				filepath.Base(p), m[1], ourRepository)
+		}
+	}
+
+	// A walk that matched nothing would report everything is fine.
+	if checked == 0 {
+		t.Error("no repository link was found in .github or SECURITY.md at all, " +
+			"so this guard checked nothing")
+	}
+}
+
+// The issue forms are shaped the way GitHub needs them.
+//
+// A form GitHub cannot read is not reported anywhere a person would see. It
+// simply stops offering the template, and the first anybody knows is that
+// reports arrive without the version in them.
+func TestTheIssueFormsAreShapedTheWayGitHubNeeds(t *testing.T) {
+	dir := filepath.Join(repoRoot(t), ".github", "ISSUE_TEMPLATE")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading the issue templates: %v", err)
+	}
+
+	allowed := map[string]bool{
+		"markdown": true, "input": true, "textarea": true,
+		"dropdown": true, "checkboxes": true,
+	}
+
+	forms := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".yml") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+
+		if name == "config.yml" {
+			var cfg struct {
+				Blank bool `yaml:"blank_issues_enabled"`
+			}
+			if err := yaml.Unmarshal(body, &cfg); err != nil {
+				t.Errorf("%s does not parse: %v", name, err)
+			}
+			if cfg.Blank {
+				t.Errorf("%s leaves blank issues enabled, so a report can arrive with "+
+					"none of the things that make it answerable", name)
+			}
+			continue
+		}
+
+		var form struct {
+			Name        string   `yaml:"name"`
+			Description string   `yaml:"description"`
+			Labels      []string `yaml:"labels"`
+			Body        []struct {
+				Type       string `yaml:"type"`
+				ID         string `yaml:"id"`
+				Attributes struct {
+					Label string `yaml:"label"`
+					Value string `yaml:"value"`
+				} `yaml:"attributes"`
+			} `yaml:"body"`
+		}
+		if err := yaml.Unmarshal(body, &form); err != nil {
+			t.Errorf("%s does not parse: %v", name, err)
+			continue
+		}
+		forms++
+
+		if form.Name == "" || form.Description == "" {
+			t.Errorf("%s has no name or no description, which are what the chooser "+
+				"shows a person deciding where to report", name)
+		}
+		if len(form.Body) == 0 {
+			t.Errorf("%s asks for nothing", name)
+		}
+		for _, label := range form.Labels {
+			if strings.TrimSpace(label) == "" {
+				t.Errorf("%s applies an empty label", name)
+			}
+		}
+
+		seen := map[string]bool{}
+		for i, item := range form.Body {
+			if !allowed[item.Type] {
+				t.Errorf("%s field %d has type %q, which GitHub does not accept",
+					name, i, item.Type)
+				continue
+			}
+			if item.Type == "markdown" {
+				if item.Attributes.Value == "" {
+					t.Errorf("%s field %d is a markdown block with nothing in it", name, i)
+				}
+				continue
+			}
+			if item.Attributes.Label == "" {
+				t.Errorf("%s field %d has no label", name, i)
+			}
+			if item.ID == "" {
+				t.Errorf("%s field %d has no id", name, i)
+				continue
+			}
+			if seen[item.ID] {
+				t.Errorf("%s uses the id %q twice, and GitHub refuses the whole form for that",
+					name, item.ID)
+			}
+			seen[item.ID] = true
+		}
+	}
+
+	if forms == 0 {
+		t.Error("no issue form was read, so this guard checked nothing")
+	}
+}
+
+// The dependency review asks for no write scope, and posts no comment.
+//
+// Owner decision, 2026-08-27: a failing gate says what the comment would, so the
+// comment is not worth a write scope. The two go together - the action needs
+// `pull-requests: write` to post, so leaving the comment on while dropping the
+// scope would be a setting that silently does nothing.
+func TestTheDependencyReviewAsksForNoWriteScope(t *testing.T) {
+	path := filepath.Join(repoRoot(t), ".github", "workflows", "dependency-review.yml")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading the dependency review workflow: %v", err)
+	}
+	text := withoutYamlComments(string(body))
+
+	if strings.Contains(text, "write") {
+		t.Error("the dependency review workflow asks for a write scope.\n" +
+			"It needs contents: read and nothing more. A write scope kept for a " +
+			"convenience is one a job added later inherits without anybody deciding.")
+	}
+	if strings.Contains(text, "comment-summary-in-pr") {
+		t.Error("the dependency review posts a summary comment again.\n" +
+			"That needs pull-requests: write, which this workflow deliberately does " +
+			"not have, so the setting would do nothing while looking like it does.")
+	}
+}

--- a/internal/guard/onerun_test.go
+++ b/internal/guard/onerun_test.go
@@ -1,0 +1,95 @@
+package guard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ciHeader is everything above the jobs, with comments removed.
+//
+// Scoped rather than searched whole, because a trigger is a claim about when
+// the suite runs and a match anywhere else in a six hundred line file would
+// satisfy a careless assertion without meaning anything.
+func ciHeader(t *testing.T) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(repoRoot(t), ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("reading ci.yml: %v", err)
+	}
+	text := withoutYamlComments(string(body))
+	head, _, found := strings.Cut(text, "\njobs:")
+	if !found {
+		t.Fatalf("ci.yml has no jobs block, so this guard cannot tell a trigger from a job")
+	}
+	return head
+}
+
+// The suite runs once for one change.
+//
+// Measured on pull request 4, the first this project had: every job appeared
+// twice, once for the branch push and once for the pull request event, and the
+// race detector ran on both at about ten minutes each. An unfiltered `push:`
+// means every branch push runs the whole suite, and every branch here now
+// reaches main through a pull request, which runs it again.
+//
+// The pull request trigger is asserted alongside, because removing that instead
+// would also stop the doubling and would be much worse: a pull request from a
+// fork would never be checked at all, and the contexts the branch ruleset
+// requires would never report.
+func TestTheSuiteRunsOncePerChange(t *testing.T) {
+	head := ciHeader(t)
+
+	if !strings.Contains(head, "branches: [main]") {
+		t.Error("ci.yml runs on every push to every branch.\n" +
+			"With work reaching main through pull requests, that runs the whole suite " +
+			"twice for one change - measured on pull request 4, including the race " +
+			"detector at about ten minutes a time.\n" +
+			"Limit the push trigger: `push:` with `branches: [main]` under it.")
+	}
+	if !strings.Contains(head, "pull_request:") {
+		t.Error("ci.yml no longer runs on pull_request.\n" +
+			"That is not a way to stop the suite running twice. A pull request from a " +
+			"fork would go unchecked, and the contexts the branch ruleset requires " +
+			"would never report, so nothing could be merged.")
+	}
+}
+
+// The race detector is asked about the right pair of commits.
+//
+// It runs when one of the three files concurrency lives in has changed, decided
+// on 2026-08-20 after it measured 10m31s against about a minute for the rest.
+// The comparison used `github.event.before`, which belongs to a push and is
+// empty on a pull request - so from the day this project started taking pull
+// requests, every one of them answered "touched" and the detector was back to
+// running on everything. The decision was undone by a change somewhere else,
+// which is the failure this project keeps meeting.
+//
+// On a pull request the commit to compare against is the base, and github.sha
+// is the merge commit, so the difference between them is what the pull request
+// changes.
+func TestTheRaceDetectorAsksAboutWhatThePullRequestChanges(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join(repoRoot(t), ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("reading ci.yml: %v", err)
+	}
+	text := withoutYamlComments(string(body))
+
+	if !strings.Contains(text, "github.event.pull_request.base.sha") {
+		t.Error("the job deciding whether the race detector runs never looks at the " +
+			"pull request's base.\n" +
+			"github.event.before belongs to a push and is empty on a pull request, so " +
+			"the comparison falls through to 'anything unclear counts as touched' and " +
+			"the detector runs on every pull request - which is the thing 2026-08-20 " +
+			"decided it should stop doing.")
+	}
+
+	// The fallback has to survive too. A push to main has no pull request, and
+	// dropping `before` would send every push down the unclear branch instead -
+	// the same defect facing the other way.
+	if !strings.Contains(text, "github.event.before") {
+		t.Error("the comparison no longer falls back to github.event.before, so a push " +
+			"to main has nothing to compare against and counts as touched every time.")
+	}
+}


### PR DESCRIPTION
> **Stacked on #5.** This branch contains that commit, so merge #5 first. The two
> touch no file in common, so neither order can conflict - but merged the other way
> round this one carries #5 along with it.

Issue forms, a security policy, a code of conduct and a CODEOWNERS file, brought
over from a sibling repository of the same author and **adapted rather than
copied**.

That project loads a kernel-mode driver, asks for administrator rights, and signs
its releases behind a hardware token. This one does none of those things. A policy
carried across unchanged would have described a program that does not exist.

## What was measured before it was written down

- Private vulnerability reporting is **enabled** on this repository, so pointing
  people at it is not a dead instruction.
- There are **zero** repository secrets.
- The command line binary links **no network package at all**. The window binary
  links one because the graphical toolkit imports it, and nothing here calls it.
- The three labels the forms apply - `bug`, `enhancement`, `question` - already
  exist.
- `tfg version` prints the version the bug form asks for, and every command and
  format identifier named in a template is one the binary really offers.

## The forms

They ask for what makes a report answerable **here**: the version, the operating
system, the processor architecture, which surface, the format, the command or the
recipe, and the exit code. The exit codes are a frozen part of this tool's
contract, so a wrong one is a bug on its own even when the files came out right.
Architecture is asked because this tool promises the same bytes on every machine
and the one measured difference between amd64 and arm64 was a rendering difference.

Blank issues are off. A third form catches whatever fits neither of the other two,
because a question belongs on the tracker where the next person can find the
answer rather than in private mail.

## The guard, and the defect it is for

A link left pointing at the other project reads perfectly. The worst of them - the
private reporting link in the issue chooser - would send somebody's vulnerability
report to a repository that is not this one, and nobody here would learn of it.

The guard refuses any `https://github.com/owner/repo` under `.github/` or in
`SECURITY.md` that is not this repository. It is anchored on `https://` so the
module paths that fill the workflows are not swept in, and `CODE_OF_CONDUCT.md` is
exempt by name: it is the Contributor Covenant carried word for word, and its
attribution links somewhere else on purpose.

Two more guards hold the form shape - a repeated `id` makes GitHub refuse the whole
form, silently, and the first anybody would know is that reports start arriving
without the version in them.

Three mutations, all proven red.

## Also here

The dependency review no longer comments on a pull request and no longer asks for
`pull-requests: write`. A failing check says what the comment would, and the log
names the dependency. The two moved together because the action needs that scope to
post, so dropping one without the other leaves a setting that looks like it works
and does nothing.

## Not copied on purpose

The source file opened with a block carrying the author's full name and email
address, above the policy itself. It is not part of a security policy, and
publishing personal details is the owner's decision rather than mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
