### PR TITLE
Seven fonts and ninety-seven icons that shipped named nowhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,21 @@ because it turns other people's test suites red.
 
 ### Fixed
 
+- The notices that travel with a release now name the fonts and drawings the
+  window binary carries. Seven font files and ninety-seven images are compiled
+  into `tfg-gui` from inside the graphics toolkit, under the SIL Open Font
+  License, the Bitstream Vera licence and MIT, and `THIRD-PARTY-NOTICES.md`
+  named none of them. It described modules, and a font is a file inside a
+  module rather than a module of its own, so nothing that asked about modules
+  could see them. Those licences ask for their notices to travel with the
+  bytes, so the full texts are in that file now.
+
+  `tfg`, the command line binary, embeds none of this and never did. The file
+  says so as well, rather than leaving it to be assumed.
+
+  The same file also stated that `golang.org/x/text` was version 0.40.0 while
+  every binary linked 0.41.0. Both numbers are now compared with the build.
+
 - `verify` and `cleanup` no longer contradict each other about a file stored
   under a different case. On Windows and on a Mac, `REPORT.TXT` and `report.txt`
   are one file, and `verify` used to call such a file `extra` - the word it uses

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -76,7 +76,7 @@ Source: <https://github.com/goccy/go-yaml>
 
 ## golang.org/x/text
 
-Version 0.40.0. Supplies Unicode normalisation, used to decide whether two file
+Version 0.41.0. Supplies Unicode normalisation, used to decide whether two file
 names are one name spelled two ways.
 
 ```
@@ -501,6 +501,214 @@ THE SOFTWARE.
 
 ---
 
+## Files the window binary carries that are not code
+
+The toolkit compiles fonts and drawings into the binary. They are not modules,
+so a list of modules never mentions them - which is how they shipped unnamed
+until this section was written on 2026-08-28. Seven fonts and ninety-seven
+images arrive this way, and their licences ask for their notices to travel with
+them.
+
+What is listed here was measured by asking the compiler which files each
+package embeds, not by reading its source. The copyright lines were read out of
+the font files themselves.
+
+| what | comes from | licence | copyright |
+|---|---|---|---|
+| Noto Sans, four styles | `fyne.io/fyne/v2/theme` | OFL-1.1 | Copyright 2015 Google Inc. All Rights Reserved. |
+| Inter, symbols only | `fyne.io/fyne/v2/theme` | OFL-1.1 | (c) 2020 The Inter Project Authors |
+| DejaVu Sans Mono for Powerline | `fyne.io/fyne/v2/theme` | Bitstream-Vera | (c) 2003 Bitstream, Inc. DejaVu changes are in the public domain |
+| EmojiOne Color | `fyne.io/fyne/v2/theme` | MIT, and read the note below | Copyright 2016 Adobe Systems Incorporated |
+| Fyne icon set, 96 drawings and one image | `fyne.io/fyne/v2/theme` | BSD-3-Clause | (C) 2018 Fyne.io developers (see AUTHORS) |
+| Fyne translations, 15 files of toolkit wording | `fyne.io/fyne/v2/lang` | BSD-3-Clause | (C) 2018 Fyne.io developers (see AUTHORS) |
+| Fyne shaders, 14 programs that draw the screen | `fyne.io/fyne/v2/internal/painter/gl` | BSD-3-Clause | (C) 2018 Fyne.io developers (see AUTHORS) |
+
+`tfg`, the command line binary, embeds none of this. It has no toolkit in it.
+
+Neither font licence declares a Reserved Font Name, so the identifier above is
+OFL-1.1 rather than OFL-1.1-RFN. Inter is a trademark of Rasmus Andersson.
+
+**EmojiOne Color says two different things about itself.** The toolkit ships it
+with an MIT licence naming Adobe Systems Incorporated. The font's own metadata
+states a Creative Commons Attribution 4.0 licence and asks for attribution.
+Both can be true at once, because the software that draws a glyph and the
+artwork it draws are not the same work, so both are recorded here rather than
+one of them being chosen.
+
+The last three rows are the toolkit's own work and travel under the licence
+already reproduced for `fyne.io/fyne/v2`. The toolkit ships no separate licence
+for its icons and says nothing about where they came from.
+
+The three texts below are reproduced from the files that ship inside the pinned
+module. The Open Font License there is typeset with dashes and quotation marks
+outside ASCII, and every file in this repository is ASCII, so those characters
+and only those were replaced by their plain equivalents.
+
+### SIL Open Font License 1.1
+
+Applies to Noto Sans and to Inter.
+
+```
+------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide development of collaborative font projects, to support the font creation efforts of academic and linguistic communities, and to provide a free and open framework in which fonts may be shared and improved in partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and redistributed freely as long as they are not sold by themselves. The fonts, including any derivative works, can be bundled, embedded, redistributed and/or sold with any software provided that any reserved names are not used by derivative works. The fonts and derivatives, however, cannot be released under any other type of license. The requirement for fonts to remain under this license does not apply to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright Holder(s) under this license and clearly marked as such. This may include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting, or substituting-in part or in whole-any of the components of the Original Version, by changing formats or by porting the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining a copy of the Font Software, to use, study, copy, merge, embed, modify, redistribute, and sell modified and unmodified copies of the Font Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled, redistributed and/or sold with any software, provided that each copy contains the above copyright notice and this license. These can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font Name(s) unless explicit written permission is granted by the corresponding Copyright Holder. This restriction only applies to the primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font Software shall not be used to promote, endorse or advertise any Modified Version, except to acknowledge the contribution(s) of the Copyright Holder(s) and the Author(s) or with their explicit written permission.
+
+5) The Font Software, modified or unmodified, in part or in whole, must be distributed entirely under this license, and must not be distributed under any other license. The requirement for fonts to remain under this license does not apply to any document created using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
+```
+
+### Bitstream Vera Fonts Copyright
+
+Applies to DejaVu Sans Mono for Powerline.
+
+```
+Fonts are (c) Bitstream (see below). DejaVu changes are in public domain.
+Glyphs imported from Arev fonts are (c) Tavmjong Bah (see below)
+
+Bitstream Vera Fonts Copyright
+------------------------------
+
+Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is
+a trademark of Bitstream, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of the fonts accompanying this license ("Fonts") and associated
+documentation files (the "Font Software"), to reproduce and distribute the
+Font Software, including without limitation the rights to use, copy, merge,
+publish, distribute, and/or sell copies of the Font Software, and to permit
+persons to whom the Font Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright and trademark notices and this permission notice shall
+be included in all copies of one or more of the Font Software typefaces.
+
+The Font Software may be modified, altered, or added to, and in particular
+the designs of glyphs or characters in the Fonts may be modified and
+additional glyphs or characters may be added to the Fonts, only if the fonts
+are renamed to names not containing either the words "Bitstream" or the word
+"Vera".
+
+This License becomes null and void to the extent applicable to Fonts or Font
+Software that has been modified and is distributed under the "Bitstream
+Vera" names.
+
+The Font Software may be sold as part of a larger software package but no
+copy of one or more of the Font Software typefaces may be sold by itself.
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT,
+TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME
+FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING
+ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
+THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE
+FONT SOFTWARE.
+
+Except as contained in this notice, the names of Gnome, the Gnome
+Foundation, and Bitstream Inc., shall not be used in advertising or
+otherwise to promote the sale, use or other dealings in this Font Software
+without prior written authorization from the Gnome Foundation or Bitstream
+Inc., respectively. For further information, contact: fonts at gnome dot
+org. 
+
+Arev Fonts Copyright
+------------------------------
+
+Copyright (c) 2006 by Tavmjong Bah. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the fonts accompanying this license ("Fonts") and
+associated documentation files (the "Font Software"), to reproduce
+and distribute the modifications to the Bitstream Vera Font Software,
+including without limitation the rights to use, copy, merge, publish,
+distribute, and/or sell copies of the Font Software, and to permit
+persons to whom the Font Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright and trademark notices and this permission notice
+shall be included in all copies of one or more of the Font Software
+typefaces.
+
+The Font Software may be modified, altered, or added to, and in
+particular the designs of glyphs or characters in the Fonts may be
+modified and additional glyphs or characters may be added to the
+Fonts, only if the fonts are renamed to names not containing either
+the words "Tavmjong Bah" or the word "Arev".
+
+This License becomes null and void to the extent applicable to Fonts
+or Font Software that has been modified and is distributed under the 
+"Tavmjong Bah Arev" names.
+
+The Font Software may be sold as part of a larger software package but
+no copy of one or more of the Font Software typefaces may be sold by
+itself.
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL
+TAVMJONG BAH BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+Except as contained in this notice, the name of Tavmjong Bah shall not
+be used in advertising or otherwise to promote the sale, use or other
+dealings in this Font Software without prior written authorization
+from Tavmjong Bah. For further information, contact: tavmjong @ free
+. fr.
+```
+
+### EmojiOne Color
+
+```
+MIT License
+
+Copyright (c) 2016 Adobe Systems Incorporated
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
+---
+
 ## Modules named in the build graph but not linked
 
 `go list -m all` also names `golang.org/x/mod`, `golang.org/x/sync` and
@@ -513,7 +721,8 @@ above.
 
 ## Not used
 
-`tfg` embeds no fonts, images, sound or other third party assets. The pixel
+`tfg`, the command line binary, embeds no fonts, images, sound or other
+third party assets. The window binary does, and they are listed above. The pixel
 font that draws the label on a generated image is drawn in this repository, in
 `internal/format/imagelabel/font.go`, so that a font licence is not a question
 this project has to answer. The filler vocabulary is a short list of ordinary

--- a/internal/guard/embeddedassets_test.go
+++ b/internal/guard/embeddedassets_test.go
@@ -1,0 +1,172 @@
+package guard
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/donislawdev/TestingFilesGenerator/internal/legal"
+)
+
+// A module list cannot see a font.
+//
+// Measured on 2026-08-27: the window binary carries seven font files and
+// ninety-seven images that arrive from inside fyne.io/fyne/v2, under the Open
+// Font License, the Bitstream Vera licence and MIT - and the notices named none
+// of them. Nothing could have caught it. Every mechanism this project had asked
+// about MODULES: go list -deps reports modules, the dependency gate reviews the
+// module graph a pull request adds, a scanner reads the modules recorded in the
+// binary, and the notices guard compares that list with a table. A font is not
+// a module. It is a file inside one, with a licence of its own, and no question
+// about modules reaches it. See docs/OBSERVATIONS.md, O150.
+//
+// So this asks a different question, and asks the compiler rather than the
+// source: which files does each package compile into the binary. The first
+// version of that finding read one source file and missed a font, which is the
+// second reason this guard exists rather than a careful reader.
+func TestEveryFileEmbeddedFromSomebodyElseIsAccountedFor(t *testing.T) {
+	seen := map[string]bool{}
+	matched := map[string]bool{}
+	total := 0
+
+	for _, target := range []string{"../../cmd/tfg-gui", "../../cmd/tfg"} {
+		for _, goos := range []string{"windows", "linux", "darwin"} {
+			total += accountForBuild(t, target, goos, seen, matched)
+		}
+	}
+
+	// The toolkit alone embeds 133 files, so a run that finds a handful found
+	// a shell with cgo switched off rather than a tree with nothing in it.
+	// Without this the guard would pass by seeing nothing, which is the failure
+	// it is here to prevent.
+	if total < 50 {
+		t.Fatalf("only %d embedded file(s) were found across both binaries and three systems, "+
+			"which is too few to be the real set - check that cgo is enabled in this shell", total)
+	}
+
+	var stale []string
+	for _, asset := range legal.Assets() {
+		if !matched[asset.Name] {
+			stale = append(stale, asset.Name+" (declared in "+asset.Package+")")
+		}
+	}
+	if len(stale) > 0 {
+		sort.Strings(stale)
+		t.Errorf("%d entr(y/ies) in the licence registry match nothing any build embeds:\n  %s\n"+
+			"An entry for bytes that no longer ship is a notice nobody needs, and it hides the day "+
+			"the real thing was replaced by something else.", len(stale), strings.Join(stale, "\n  "))
+	}
+	t.Logf("%d embedded file(s) from other modules, all accounted for by %d registry entr(y/ies)",
+		total, len(legal.Assets()))
+}
+
+// accountForBuild walks one platform's build and returns how many files it
+// added. Split out rather than nested inside the test because the depth ceiling
+// said so, and the ceiling is a measurement rather than a preference - see
+// docs/QUALITY.md.
+func accountForBuild(t *testing.T, target, goos string, seen, matched map[string]bool) int {
+	t.Helper()
+	added := 0
+	for pkg, files := range embeddedFiles(t, target, goos) {
+		added += accountForPackage(t, pkg, files, seen, matched)
+	}
+	return added
+}
+
+// accountForPackage does one package, skipping what another platform already
+// answered for. Three systems are asked and they agree about most of the tree,
+// so without seen the same font would be reported six times.
+func accountForPackage(t *testing.T, pkg string, files []string, seen, matched map[string]bool) int {
+	t.Helper()
+	added := 0
+	for _, file := range files {
+		if seen[pkg+" "+file] {
+			continue
+		}
+		seen[pkg+" "+file] = true
+		added++
+		accountFor(t, pkg, file, matched)
+	}
+	return added
+}
+
+// accountFor requires exactly one registry entry to claim a file. None means
+// bytes ship unnamed. Two means the notices could say two different licences
+// for one file and nothing would notice which one a reader believed.
+func accountFor(t *testing.T, pkg, file string, matched map[string]bool) {
+	t.Helper()
+	var claims []string
+	for _, asset := range legal.Assets() {
+		if asset.Package == pkg && asset.Covers(file) {
+			claims = append(claims, asset.Name)
+			matched[asset.Name] = true
+		}
+	}
+	switch len(claims) {
+	case 1:
+	case 0:
+		t.Errorf("%s embeds %s into a binary and no entry in internal/legal accounts for it.\n"+
+			"Read the licence that ships with it, add an entry, and put it in THIRD-PARTY-NOTICES.md. "+
+			"Bytes that travel with a release and are named nowhere are the thing this guard exists for.",
+			pkg, file)
+	default:
+		sort.Strings(claims)
+		t.Errorf("%s embeds %s and %d registry entries claim it: %s.\n"+
+			"One file, one licence, one entry - otherwise the notices can carry two answers "+
+			"and nobody can tell which one is true.", pkg, file, len(claims), strings.Join(claims, ", "))
+	}
+}
+
+// The notices are what actually travels with a release, so an entry that is
+// only in the code is an entry nobody downloading a binary can read.
+func TestEveryEmbeddedAssetIsNamedInTheNotices(t *testing.T) {
+	root := repoRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, "THIRD-PARTY-NOTICES.md"))
+	if err != nil {
+		t.Skipf("no notices file here: %v", err)
+	}
+	text := string(body)
+	for _, asset := range legal.Assets() {
+		if !strings.Contains(text, asset.Name) {
+			t.Errorf("the registry carries %q and the notices never name it - "+
+				"the notices are the copy that travels with the binary", asset.Name)
+		}
+		if !strings.Contains(text, asset.SPDX) {
+			t.Errorf("%s ships under %s and the notices never state that licence", asset.Name, asset.SPDX)
+		}
+		if asset.Copyright == "" {
+			t.Errorf("%s has no copyright line, and every licence here requires one to travel", asset.Name)
+		}
+	}
+}
+
+// embeddedFiles asks one platform's build which files each package embeds.
+//
+// CGO_ENABLED is set rather than inherited, for the reason written beside the
+// notices guard: the toolkit hides its real dependencies behind cgo build
+// constraints, so a shell with cgo off reports a tree with almost nothing in
+// it. Our own module is skipped - its embedded files are our own work, and the
+// question here is what somebody else's code brings along.
+func embeddedFiles(t *testing.T, target, goos string) map[string][]string {
+	t.Helper()
+	cmd := exec.Command("go", "list", "-deps", "-f",
+		"{{if and .EmbedFiles .Module}}{{.Module.Path}}|{{.ImportPath}}|{{range .EmbedFiles}}{{.}} {{end}}{{end}}",
+		target)
+	cmd.Env = append(os.Environ(), "GOOS="+goos, "CGO_ENABLED=1")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Skipf("go list for %s is not available here: %v", goos, err)
+	}
+	found := map[string][]string{}
+	for _, line := range strings.Split(string(out), "\n") {
+		parts := strings.SplitN(strings.TrimSpace(line), "|", 3)
+		if len(parts) != 3 || strings.Contains(parts[0], "donislawdev") {
+			continue
+		}
+		found[parts[1]] = strings.Fields(parts[2])
+	}
+	return found
+}

--- a/internal/guard/layers_test.go
+++ b/internal/guard/layers_test.go
@@ -20,6 +20,13 @@ var layer = map[string]int{
 	// everything and already allowed to look anywhere. See internal/site.
 	"internal/site": 0,
 
+	// The licence registry imports nothing of ours either, and for the same
+	// kind of reason: it is a list of facts about what we ship, read by the
+	// guards, by the licence command and by whatever renders an SBOM. A list
+	// that could reach into the engine would be a list that could disagree
+	// with itself depending on who asked.
+	"internal/legal": 0,
+
 	"internal/format":            1,
 	"internal/format/all":        1,
 	"internal/format/imagelabel": 1,

--- a/internal/guard/licenceregistry_test.go
+++ b/internal/guard/licenceregistry_test.go
@@ -1,0 +1,134 @@
+package guard
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/donislawdev/TestingFilesGenerator/internal/legal"
+)
+
+// internal/legal is the reviewed list of what we ship, and a list nobody checks
+// is a list that describes last month.
+//
+// The notices file has been held to the build since 2026-08-05 and that is not
+// enough on its own: it is prose, so nothing can read a licence out of it, and
+// the SBOM and the licence command both need one in a form a program can use.
+// This is the same fact written where a program can reach it, so this guard
+// asks the build the same question the notices guard asks, and then asks the
+// two written answers to agree.
+//
+// "std" is here and comes back from no build, deliberately. The Go runtime is
+// in every binary this project produces and is not a module, so no list of
+// modules will ever name it - which is exactly why it would go missing.
+const runtimeEntry = "std"
+
+func TestEveryModuleTheBinariesLinkHasAReviewedLicence(t *testing.T) {
+	built, _ := shipped(t, "../../cmd/tfg-gui")
+	fromCLI, _ := shipped(t, "../../cmd/tfg")
+	for path, version := range fromCLI {
+		built[path] = version
+	}
+	if len(built) < 5 {
+		t.Fatalf("the build reported %d modules, too few to be the real set", len(built))
+	}
+
+	registry := map[string]legal.Module{}
+	for _, m := range legal.Modules() {
+		if _, twice := registry[m.Path]; twice {
+			t.Errorf("%s has two entries in the registry, so one of them is describing nothing", m.Path)
+		}
+		registry[m.Path] = m
+	}
+
+	var missing []string
+	for path := range built {
+		if _, ok := registry[path]; !ok {
+			missing = append(missing, path)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("%d module(s) are compiled in and have no entry in internal/legal:\n  %s\n"+
+			"Read the licence out of the module's own source and add it. An SBOM generated from "+
+			"this list would otherwise claim to be complete while missing them.",
+			len(missing), strings.Join(missing, "\n  "))
+	}
+
+	var stale []string
+	for path := range registry {
+		if path == runtimeEntry {
+			continue
+		}
+		if _, ok := built[path]; !ok {
+			stale = append(stale, path)
+		}
+	}
+	if len(stale) > 0 {
+		sort.Strings(stale)
+		t.Errorf("%d entr(y/ies) in internal/legal name a module no binary links any more:\n  %s\n"+
+			"A notice for code that does not ship is a notice nobody needs.",
+			len(stale), strings.Join(stale, "\n  "))
+	}
+	t.Logf("%d module(s) linked, %d entries in the registry including %s",
+		len(built), len(legal.Modules()), runtimeEntry)
+}
+
+// Every field that carries a licence question has to say something. An empty
+// licence reads like an answer and is not one, and an empty copyright line is
+// either a mistake or a fact that needs a sentence - one module here genuinely
+// has none, because its licence file is the unmodified Apache template.
+func TestNoEntryInTheRegistryIsSilentAboutItsLicence(t *testing.T) {
+	for _, m := range legal.Modules() {
+		if m.SPDX == "" {
+			t.Errorf("%s has no licence identifier in the registry", m.Path)
+		}
+		if m.Copyright == "" && m.Note == "" {
+			t.Errorf("%s has no copyright line and no note saying why.\n"+
+				"A blank reads like an oversight, so the reason belongs beside it.", m.Path)
+		}
+	}
+}
+
+// The registry and the notices are two written copies of one fact, and this is
+// what makes that safe: the licence in the table and the licence in the code
+// have to be the same string. Written the other way round - a document nobody
+// compares with the code - is how the version of golang.org/x/text sat at
+// 0.40.0 in the notices while every binary linked 0.41.0.
+func TestTheRegistryAndTheNoticesAgreeOnEveryLicence(t *testing.T) {
+	root := repoRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, "THIRD-PARTY-NOTICES.md"))
+	if err != nil {
+		t.Skipf("no notices file here: %v", err)
+	}
+
+	registry := map[string]string{}
+	for _, m := range legal.Modules() {
+		registry[m.Path] = m.SPDX
+	}
+
+	compared := 0
+	for _, line := range strings.Split(string(body), "\n") {
+		m := licenceRow.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		path, licence := m[1], strings.TrimSpace(m[3])
+		want, known := registry[path]
+		if !known {
+			continue // the other guard reports this, and reporting it twice buries it
+		}
+		compared++
+		if licence != want {
+			t.Errorf("the notices say %s is %s and internal/legal says %s.\n"+
+				"One of them is wrong, and the SBOM will publish whichever the code says.",
+				path, licence, want)
+		}
+	}
+	if compared < 20 {
+		t.Fatalf("only %d row(s) were compared, so this guard would pass on an empty table", compared)
+	}
+	t.Logf("%d licence(s) agree between the notices table and internal/legal", compared)
+}

--- a/internal/guard/notices_test.go
+++ b/internal/guard/notices_test.go
@@ -60,6 +60,32 @@ func unlisted(body string, built map[string]string) []string {
 
 var noticeRow = regexp.MustCompile(`^\| ` + "`" + `([^` + "`" + `]+)` + "`" + ` \| (v[^ |]+) \|`)
 
+// statedVersion is how a headed section opens: the version, then a full stop,
+// then what the module does here. Written without the leading v, because that
+// is how a person writes it in prose.
+var statedVersion = regexp.MustCompile(`(?m)^Version (\S+?)\.(?:\s|$)`)
+
+// sectionVersion reads the version a module's own section states.
+//
+// Cut on the heading rather than searched for anywhere, because two sections
+// would otherwise answer for each other and the guard would compare a number
+// with the wrong module - which is the failure it exists to catch, dressed up
+// as a pass.
+func sectionVersion(body, path string) (string, bool) {
+	_, after, found := strings.Cut(body, "\n## "+path+"\n")
+	if !found {
+		return "", false
+	}
+	if end := strings.Index(after, "\n## "); end >= 0 {
+		after = after[:end]
+	}
+	m := statedVersion.FindStringSubmatch(after)
+	if m == nil {
+		return "", false
+	}
+	return m[1], true
+}
+
 func TestTheNoticesFileNamesTheVersionsThatAreActuallyBuilt(t *testing.T) {
 	root := repoRoot(t)
 	body, err := os.ReadFile(filepath.Join(root, "THIRD-PARTY-NOTICES.md"))
@@ -74,12 +100,14 @@ func TestTheNoticesFileNamesTheVersionsThatAreActuallyBuilt(t *testing.T) {
 	t.Logf("%d module(s) across windows, linux and darwin", len(built))
 
 	listed := 0
+	inRow := map[string]bool{}
 	for _, line := range strings.Split(string(body), "\n") {
 		m := noticeRow.FindStringSubmatch(line)
 		if m == nil {
 			continue
 		}
 		path, version := m[1], m[2]
+		inRow[path] = true
 		want, ok := built[path]
 		if !ok {
 			t.Errorf("the notices file lists %s and nothing links it any more - "+
@@ -96,6 +124,31 @@ func TestTheNoticesFileNamesTheVersionsThatAreActuallyBuilt(t *testing.T) {
 	}
 	if listed < 5 {
 		t.Fatalf("only %d rows were compared, so this guard would pass on an empty table", listed)
+	}
+
+	// The modules named by a section instead of a row, which is both binaries'
+	// worth of the command line. Until 2026-08-28 nothing compared the number
+	// those sections state: the file said golang.org/x/text was 0.40.0 while
+	// every binary linked 0.41.0, and this guard was green because it read only
+	// rows. The section is the stronger notice and had the weaker check - and
+	// it covers the two modules that almost everybody actually runs.
+	for path, want := range built {
+		if inRow[path] {
+			continue
+		}
+		stated, found := sectionVersion(string(body), path)
+		if !found {
+			t.Errorf("%s has a section of its own in the notices and that section states no version.\n"+
+				"Write \"Version %s.\" under the heading, so the number can be compared with the build.",
+				path, strings.TrimPrefix(want, "v"))
+			continue
+		}
+		listed++
+		if stated != strings.TrimPrefix(want, "v") {
+			t.Errorf("the notices say %s is version %s and the build links %s.\n"+
+				"A section carries the whole licence text, so a wrong number there is a notice "+
+				"about a release nobody ships.", path, stated, strings.TrimPrefix(want, "v"))
+		}
 	}
 
 	// And the other direction, which is the one that was missing. Until

--- a/internal/legal/assets.go
+++ b/internal/legal/assets.go
@@ -1,0 +1,75 @@
+// The files that arrive inside somebody else's module and end up in a binary
+// here. Every one of them was found by asking the compiler, not by reading
+// source: `go list -deps -f '{{.EmbedFiles}}'` answers for a whole package, and
+// the first version of this work read one file instead and missed a font.
+//
+// Measured 2026-08-27 on the pinned modules: fyne.io/fyne/v2/theme embeds 104
+// files, fyne.io/fyne/v2/lang 15 and fyne.io/fyne/v2/internal/painter/gl 14.
+// The command line binary embeds nothing from anybody.
+
+package legal
+
+// The copyright lines below are read from the font files themselves - the name
+// table, records 0 and 13 - and not from memory or from the module. Where the
+// font and the module disagree, both are recorded.
+//
+// Two of them are written with "(c)" although the font writes the sign. Every
+// byte this project prints to a terminal is ASCII, and a guard says so.
+var assets = []Asset{
+	{
+		Name:      "Noto Sans",
+		Package:   "fyne.io/fyne/v2/theme",
+		Files:     []string{"font/NotoSans-Regular.ttf", "font/NotoSans-Bold.ttf", "font/NotoSans-Italic.ttf", "font/NotoSans-BoldItalic.ttf"},
+		SPDX:      "OFL-1.1",
+		Copyright: "Copyright 2015 Google Inc. All Rights Reserved.",
+		Note:      "The text of the window, in four styles. The licence requires its notice to travel with the font, which is why it is quoted in THIRD-PARTY-NOTICES.md in full.",
+	},
+	{
+		Name:      "Inter",
+		Package:   "fyne.io/fyne/v2/theme",
+		Files:     []string{"font/InterSymbols-Regular.ttf"},
+		SPDX:      "OFL-1.1",
+		Copyright: "(c) 2020 The Inter Project Authors",
+		Note:      "Symbols only. Inter is a trademark of Rasmus Andersson. Neither licence file declares a Reserved Font Name, so the identifier is OFL-1.1 rather than OFL-1.1-RFN - checked in the files, not assumed.",
+	},
+	{
+		Name:      "DejaVu Sans Mono for Powerline",
+		Package:   "fyne.io/fyne/v2/theme",
+		Files:     []string{"font/DejaVuSansMono-Powerline.ttf"},
+		SPDX:      "Bitstream-Vera",
+		Copyright: "Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. DejaVu changes are in public domain",
+		Note:      "The monospaced face. Glyphs imported from the Arev fonts are (c) Tavmjong Bah.",
+	},
+	{
+		Name:      "EmojiOne Color",
+		Package:   "fyne.io/fyne/v2/theme",
+		Files:     []string{"font/EmojiOneColor.otf"},
+		SPDX:      "MIT",
+		Copyright: "Copyright 2016 Adobe Systems Incorporated",
+		Note:      "Colour emoji. The module ships this file under MIT and the font's own metadata states CC-BY-4.0 with attribution required. Both can be true at once - font software and artwork are not the same work - so the notices record what each source says instead of choosing one.",
+	},
+	{
+		Name:      "Fyne icon set",
+		Package:   "fyne.io/fyne/v2/theme",
+		Files:     []string{"icons/"},
+		SPDX:      "BSD-3-Clause",
+		Copyright: "(C) 2018 Fyne.io developers (see AUTHORS)",
+		Note:      "Ninety-six drawings and one image, the toolkit's own. The module ships no separate licence for them and says nothing about where they came from, so they travel under its licence. Some path data matches the Material Design set, which is Apache-2.0 - either answer is a licence this project already accepts.",
+	},
+	{
+		Name:      "Fyne translations",
+		Package:   "fyne.io/fyne/v2/lang",
+		Files:     []string{"translations/"},
+		SPDX:      "BSD-3-Clause",
+		Copyright: "(C) 2018 Fyne.io developers (see AUTHORS)",
+		Note:      "Fifteen languages of toolkit wording. Ours are elsewhere and are our own.",
+	},
+	{
+		Name:      "Fyne shaders",
+		Package:   "fyne.io/fyne/v2/internal/painter/gl",
+		Files:     []string{"shaders/"},
+		SPDX:      "BSD-3-Clause",
+		Copyright: "(C) 2018 Fyne.io developers (see AUTHORS)",
+		Note:      "The programs that draw every rectangle and line on the screen.",
+	},
+}

--- a/internal/legal/legal.go
+++ b/internal/legal/legal.go
@@ -1,0 +1,104 @@
+// Package legal is the reviewed list of what a built binary of this project
+// carries that somebody else wrote: the modules it links, and the files those
+// modules compile into it.
+//
+// Why a written list at all, when a scanner can read the binary. Measured on
+// 2026-08-27 with syft 1.51.0: a scan of the window binary names all thirty
+// artefacts with exact versions and attaches a licence to one of them. The
+// inventory half is free, because Go records it in the binary itself. The
+// licence half is the half no scanner can infer, and this list is that half.
+//
+// It also carries what no module list can carry: the files a module embeds.
+// Seven fonts and ninety-seven icons reach the window binary from inside
+// fyne.io/fyne/v2, under licences of their own, and a question asked about
+// modules cannot see them. Nothing here noticed for as long as the window
+// existed - see docs/OBSERVATIONS.md, O150.
+//
+// Nothing in this package is a version. A version is a fact about a build, so
+// it is read from the build: by go list when a document is generated, and by
+// debug.ReadBuildInfo when a binary is asked about itself. A written copy would
+// be a third thing to keep true, and the one already written here drifted -
+// see O151.
+package legal
+
+import "strings"
+
+// A Module is one module that a binary of this project links.
+type Module struct {
+	// Path is the module path as go list reports it. The Go runtime and
+	// standard library are carried as "std", which is not a module and which
+	// every binary here contains.
+	Path string
+
+	// SPDX is the licence identifier, taken from the published SPDX list and
+	// read out of the module's own licence file rather than from a package
+	// index. Checked against the list on 2026-08-28.
+	SPDX string
+
+	// Copyright is the line that licence file carries, quoted rather than
+	// summarised. Empty only when the file carries none, and then Note says so
+	// - a blank that reads like an oversight is worse than a sentence.
+	Copyright string
+
+	// Note is the sentence an entry needs when the fields above do not speak
+	// for themselves: what the module does here, which system it appears on,
+	// or why a field is empty.
+	Note string
+}
+
+// An Asset is bytes that are not code: a file that some package compiles into
+// a binary of this project through a go:embed directive.
+//
+// These are the entries a module list cannot hold. A font is not a dependency,
+// it is a file inside one, and its licence is not the module's licence.
+type Asset struct {
+	// Name is what a person calls it, not what the file is called.
+	Name string
+
+	// Package is the import path that embeds the files, as go list reports it.
+	Package string
+
+	// Files are the embedded paths this entry accounts for, spelled as go list
+	// spells them. A path ending in a slash accounts for everything embedded
+	// beneath it, which is how ninety-seven icons take one entry rather than
+	// ninety-seven.
+	Files []string
+
+	// SPDX, Copyright and Note carry the same meaning as on Module. Note is
+	// where a disagreement goes: one font here says one thing in the module
+	// and another in its own metadata, and both belong in the notices.
+	SPDX      string
+	Copyright string
+	Note      string
+}
+
+// Modules returns the reviewed list of modules.
+//
+// The slice is shared rather than copied, and callers read it. That is the
+// same contract the format registry states about its own tables: this list
+// exists to be rendered and compared, and every caller in this tree does one
+// of those two things.
+func Modules() []Module { return modules }
+
+// Assets returns the reviewed list of embedded files.
+func Assets() []Asset { return assets }
+
+// Covers reports whether this entry accounts for an embedded path, spelled the
+// way go list spells it.
+func (a Asset) Covers(embedded string) bool {
+	for _, file := range a.Files {
+		if covers(file, embedded) {
+			return true
+		}
+	}
+	return false
+}
+
+// covers answers for one declared path. A trailing slash means a directory and
+// everything embedded beneath it.
+func covers(declared, embedded string) bool {
+	if strings.HasSuffix(declared, "/") {
+		return strings.HasPrefix(embedded, declared)
+	}
+	return embedded == declared
+}

--- a/internal/legal/modules.go
+++ b/internal/legal/modules.go
@@ -1,0 +1,49 @@
+// The reviewed list of modules, one entry for each module a binary of this
+// project links. Seeded from THIRD-PARTY-NOTICES.md on 2026-08-28 and held to
+// it by a guard from that day on, so the two cannot drift apart.
+//
+// There are no versions here, and that is the point. A version is a fact about
+// the build, so it is read from the build - by `go list` when a document is
+// generated, and by debug.ReadBuildInfo when a binary is asked about itself. A
+// third written copy would be a third thing to keep true.
+
+package legal
+
+// modules is the list. Copyright is the line the module's own licence file
+// carries. When it carries none, Note says so rather than leaving a blank that
+// reads like an oversight.
+var modules = []Module{
+	{Path: "github.com/goccy/go-yaml", SPDX: "MIT", Copyright: "(c) 2019 Masaaki Goshima",
+		Note: "Reads the recipe file. One of the two modules in the command line binary."},
+	{Path: "golang.org/x/text", SPDX: "BSD-3-Clause", Copyright: "Copyright 2009 The Go Authors",
+		Note: "Unicode normalisation, used to decide whether two file names are one name spelled two ways. One of the two modules in the command line binary."},
+	{Path: "std", SPDX: "BSD-3-Clause", Copyright: "Copyright 2009 The Go Authors",
+		Note: "The Go runtime and standard library, linked into every binary here. Not a module, so `go list -deps` never names it - the one entry this list carries that no build can report."},
+	{Path: "fyne.io/fyne/v2", SPDX: "BSD-3-Clause", Copyright: "(C) 2018 Fyne.io developers (see AUTHORS)"},
+	{Path: "fyne.io/systray", SPDX: "Apache-2.0", Copyright: "2014 Brave New Software Project, Inc."},
+	{Path: "github.com/BurntSushi/toml", SPDX: "MIT", Copyright: "(c) 2013 TOML authors"},
+	{Path: "github.com/FyshOS/fancyfs", SPDX: "BSD-3-Clause", Copyright: "(C) 2025 FyshOS developers (see AUTHORS)"},
+	{Path: "github.com/anthonynsimon/bild", SPDX: "MIT", Copyright: "(c) 2021 Anthony Najjar Simon"},
+	{Path: "github.com/clipperhouse/uax29/v2", SPDX: "MIT", Copyright: "(c) 2020 Matt Sherman"},
+	{Path: "github.com/fsnotify/fsnotify", SPDX: "BSD-3-Clause", Copyright: "Copyright 2012 The Go Authors"},
+	{Path: "github.com/fyne-io/image", SPDX: "BSD-3-Clause", Copyright: "(c) 2022, Fyne.io"},
+	{Path: "github.com/fyne-io/oksvg", SPDX: "BSD-3-Clause", Copyright: "(c) 2018, Steven R Wiley"},
+	{Path: "github.com/go-gl/gl", SPDX: "MIT", Copyright: "(c) 2014 Eric Woroshow"},
+	{Path: "github.com/go-gl/glfw/v3.4/glfw", SPDX: "BSD-3-Clause", Copyright: "(c) 2012 The glfw3-go Authors. All rights reserved."},
+	{Path: "github.com/go-text/render", SPDX: "BSD-3-Clause", Copyright: "2021 The go-text authors"},
+	{Path: "github.com/go-text/typesetting", SPDX: "BSD-3-Clause", Copyright: "2021 The go-text authors"},
+	{Path: "github.com/godbus/dbus/v5", SPDX: "BSD-2-Clause", Copyright: "(c) 2013, Georg Reinke (<guelfey at gmail dot com>), Google"},
+	{Path: "github.com/jeandeaual/go-locale", SPDX: "MIT", Copyright: "(c) 2020 Alexis Jeandeau"},
+	{Path: "github.com/jsummers/gobmp", SPDX: "MIT", Copyright: "(c) 2012-2015 Jason Summers"},
+	{Path: "github.com/mattn/go-runewidth", SPDX: "MIT", Copyright: "(c) 2016 Yasuhiro Matsumoto"},
+	{Path: "github.com/nfnt/resize", SPDX: "ISC", Copyright: "(c) 2012, Jan Schlicht"},
+	{Path: "github.com/nicksnyder/go-i18n/v2", SPDX: "MIT", Copyright: "(c) 2014 Nick Snyder https://github.com/nicksnyder"},
+	{Path: "github.com/rymdport/portal", SPDX: "Apache-2.0", Copyright: "",
+		Note: "The licence file is the unmodified Apache template with the copyright placeholder left in, so there is no line to quote. Published by the rymdport project, and linked on Linux only."},
+	{Path: "github.com/srwiley/oksvg", SPDX: "BSD-3-Clause", Copyright: "(c) 2018, Steven R Wiley"},
+	{Path: "github.com/srwiley/rasterx", SPDX: "BSD-3-Clause", Copyright: "(c) 2018, Steven R Wiley"},
+	{Path: "github.com/yuin/goldmark", SPDX: "MIT", Copyright: "(c) 2019 Yusuke Inuzuka"},
+	{Path: "golang.org/x/image", SPDX: "BSD-3-Clause", Copyright: "2009 The Go Authors."},
+	{Path: "golang.org/x/net", SPDX: "BSD-3-Clause", Copyright: "2009 The Go Authors."},
+	{Path: "golang.org/x/sys", SPDX: "BSD-3-Clause", Copyright: "2009 The Go Authors."},
+}


### PR DESCRIPTION
## What this fixes

The window binary compiles **seven font files and ninety-seven images** into itself from inside `fyne.io/fyne/v2` - Noto Sans in four styles, Inter Symbols, DejaVu Sans Mono for Powerline and EmojiOne Color - under the SIL Open Font License, the Bitstream Vera licence and MIT. `THIRD-PARTY-NOTICES.md` named **none** of them. Those licences ask for their notice to travel with the bytes.

`tfg`, the command line binary, embeds none of this and never did. The file says so now rather than leaving it to be assumed.

## Why nothing caught it

Every mechanism here asks about **modules**: `go list -deps`, the dependency gate, a scanner reading the binary, the notices guard reading a table. A font is a file *inside* a module, so no question about modules reaches it.

The new question is asked of the compiler, not of the source: which files does each linked package embed. `internal/legal` is the reviewed answer - licence, copyright and a note per module and per embedded file. **No versions**: a version is a fact about a build and is read from the build.

## Found while building it

The notices guard compared twenty-six module versions and **neither of the two the command line binary carries** - those are documented by a section rather than a table row. `golang.org/x/text` stood at `0.40.0` in the notices while every binary linked `0.41.0`, and the suite was green. It now compares twenty-eight.

## Guards

Four new, one extended, **nine mutations and all nine caught**:

- every embedded file is accounted for by exactly one registry entry, both directions, three systems, both binaries, with a floor of fifty files so it cannot pass by seeing nothing
- every registry entry is named in the notices, with a copyright line
- every linked module has a reviewed licence in a form a program can read
- the registry and the notices state the same licence
- a module documented by its own section has its version compared with the build

The shape ceiling caught this work twice. Neither number was raised - the code was flattened instead.

## Checked

`go test ./...` exit 0, `python tools/preflight.py --quick` 11 of 11. The SPDX identifiers were checked against the published list rather than recalled, and every copyright line was read out of the font file it belongs to.