### PR TITLE
The bill of materials comes from the registry, and the scanner guards it

### DIFF
--- a/.github/scripts/sbom_gate.py
+++ b/.github/scripts/sbom_gate.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Hold the licence registry to what a scanner finds in the built binaries.
+
+The registry is the reviewed list of what this project ships, and the bill of
+materials is generated from it. The scanner's job is not to write that document
+- measured on 2026-08-27, syft reading the window binary names all thirty
+modules with exact versions and attaches a licence to one of them - its job is
+to ASK THE REGISTRY A QUESTION: does the thing we are about to publish contain
+something the list does not know about?
+
+That direction has already paid. Seven fonts and ninety-seven drawings shipped
+inside the window binary for as long as it existed, named nowhere, because every
+check this project had asked about modules and a font is a file inside one.
+
+Usage:
+    python .github/scripts/sbom_gate.py <syft-scan.json> <ours.spdx.json>
+
+Exit codes:
+    0  every name the scan found is accounted for
+    1  the scan found something the registry does not know
+    2  the scan itself is unusable, which is not the same as a clean tree
+"""
+import json
+import re
+import sys
+
+# What a scan reports that is not a module of somebody else's, mapped to why it
+# is fine. Anything not matched here has to appear in our own document by name.
+#
+# Written as patterns rather than as names because syft spells a binary
+# classifier with the product name it read out of the file properties, and that
+# name carries the version of the day.
+NOT_A_DEPENDENCY = (
+    # The Go runtime, which syft calls stdlib and our document calls what a
+    # person calls it. Not a module, so it appears in no dependency list.
+    (r"^stdlib$", "the Go runtime, named in our document as the runtime"),
+    # The binaries themselves, recognised by their file properties.
+    (r"^testing files generator$", "the program itself"),
+    (r"^tfg(-gui)?$", "the program itself"),
+    # Our own module, which is the program rather than something it carries.
+    (r"^github\.com/donislawdev/testingfilesgenerator$", "our own module"),
+)
+
+
+def unusable(message):
+    print("sbom gate: %s" % message)
+    return 2
+
+
+def load(path):
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main(argv):
+    if len(argv) != 3:
+        return unusable("usage: sbom_gate.py <syft-scan.json> <ours.spdx.json>")
+
+    try:
+        scan = load(argv[1])
+        ours = load(argv[2])
+    except (OSError, ValueError) as err:
+        # A scanner that fell over writes something that is not a report, and a
+        # gate reading its exit code would call that a clean tree. Measured in
+        # this repository on 2026-08-27, with a different scanner and a 23 byte
+        # file that was not JSON.
+        return unusable("cannot read a report: %s" % err)
+
+    artifacts = scan.get("artifacts")
+    if not artifacts:
+        return unusable("the scan names no artifact at all, so it scanned nothing")
+    files = len(scan.get("files", []) or [])
+    print("scan: %d artifact(s), %d file(s) read" % (len(artifacts), files))
+
+    known = {package["name"].strip().lower() for package in ours.get("packages", [])}
+    if len(known) < 10:
+        return unusable("our own document holds %d packages, which cannot be right" % len(known))
+
+    unaccounted = []
+    for artifact in artifacts:
+        name = str(artifact.get("name", "")).strip()
+        low = name.lower()
+        if low in known:
+            continue
+        if any(re.search(pattern, low) for pattern, _why in NOT_A_DEPENDENCY):
+            continue
+        unaccounted.append("%s %s" % (name, artifact.get("version", "")))
+
+    if unaccounted:
+        print("\nThe built binaries contain components the licence registry does not know:\n")
+        for line in sorted(set(unaccounted)):
+            print("  %s" % line)
+        print(
+            "\nRead the licence that ships with each of them, add an entry to internal/legal,\n"
+            "and put it in THIRD-PARTY-NOTICES.md before releasing. An SBOM generated from\n"
+            "that registry would otherwise claim to be complete while missing them."
+        )
+        return 1
+
+    print("every component the scan found is accounted for by the registry")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,6 +440,73 @@ jobs:
         # have called that a clean tree. The gate reads the report.
         run: python .github/scripts/semgrep_gate.py semgrep.json
 
+  sbom:
+    name: bill of materials
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.14"
+
+      - name: graphics and windowing headers
+        # The window links OpenGL through C, so without these the toolkit does
+        # not compile at all - and a scan of a binary that was never built is a
+        # scan of nothing. Taken from the toolkit's own CI, the same list the
+        # release workflow uses.
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgl1-mesa-dev \
+            libwayland-dev \
+            libx11-dev \
+            libxkbcommon-dev \
+            xorg-dev
+
+      - name: build what a release would publish
+        # Both binaries, because they do not carry the same code: the command
+        # line links two modules and the window twenty-eight plus the fonts and
+        # drawings they bring. Scanning one of them would ask half the question.
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          CGO_ENABLED=0 go build -trimpath -o dist/tfg ./cmd/tfg
+          CGO_ENABLED=1 go build -trimpath -o dist/tfg-gui ./cmd/tfg-gui
+          ls -l dist
+
+      - name: the document we would publish
+        # Generated from internal/legal, the reviewed list of what we ship, with
+        # versions read from the build. Not from a scan: measured 2026-08-27,
+        # syft reading the window binary names every module with an exact
+        # version and attaches a licence to one of thirty.
+        run: go run ./internal/legal/cmd/sbom -seed "${GITHUB_SHA}" -o ours.spdx.json
+
+      - name: scan the binaries
+        # Pinned by commit like every other action here. The scan is evidence,
+        # not the document: its job is to ask whether the built binaries contain
+        # something the registry does not know about.
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+        with:
+          path: dist
+          format: syft-json
+          output-file: scan.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: the registry has to account for everything the scan found
+        # Separate from the scan for the reason the semgrep gate is separate: a
+        # scanner that falls over can still exit zero, and a gate reading the
+        # exit code would call that a clean tree. This one reads the report, and
+        # refuses when the report is unusable rather than treating it as empty.
+        run: python .github/scripts/sbom_gate.py scan.json ours.spdx.json
+
   touched:
     name: what this push touched
     runs-on: ubuntu-latest

--- a/internal/guard/layers_test.go
+++ b/internal/guard/layers_test.go
@@ -27,6 +27,12 @@ var layer = map[string]int{
 	// with itself depending on who asked.
 	"internal/legal": 0,
 
+	// The generator of the bill of materials. A main package, so nothing can
+	// import it and it cannot reach a binary by accident. It sits with the
+	// other commands because it imports the registry and the version, and
+	// because it is a program somebody runs rather than a library.
+	"internal/legal/cmd/sbom": 5,
+
 	"internal/format":            1,
 	"internal/format/all":        1,
 	"internal/format/imagelabel": 1,

--- a/internal/guard/sbom_test.go
+++ b/internal/guard/sbom_test.go
@@ -1,0 +1,203 @@
+package guard
+
+import (
+	"encoding/json"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/donislawdev/TestingFilesGenerator/internal/legal"
+	"github.com/donislawdev/TestingFilesGenerator/internal/version"
+)
+
+// The bill of materials is the document somebody else's compliance process
+// reads, and the one place where being quietly incomplete is worst: a list that
+// omits what it cannot see still claims to be a list of everything.
+//
+// So it is generated from the registry rather than scanned out of a build, and
+// these ask whether it says what this project ships.
+
+// spdxDoc is the part of the document these guards read back.
+type spdxDoc struct {
+	SPDXVersion       string `json:"spdxVersion"`
+	DataLicense       string `json:"dataLicense"`
+	SPDXID            string `json:"SPDXID"`
+	Name              string `json:"name"`
+	DocumentNamespace string `json:"documentNamespace"`
+	CreationInfo      struct {
+		Created  string   `json:"created"`
+		Creators []string `json:"creators"`
+	} `json:"creationInfo"`
+	Packages []struct {
+		SPDXID           string `json:"SPDXID"`
+		Name             string `json:"name"`
+		VersionInfo      string `json:"versionInfo"`
+		DownloadLocation string `json:"downloadLocation"`
+		LicenseConcluded string `json:"licenseConcluded"`
+		LicenseDeclared  string `json:"licenseDeclared"`
+		CopyrightText    string `json:"copyrightText"`
+	} `json:"packages"`
+	Relationships []struct {
+		SPDXElementID      string `json:"spdxElementId"`
+		RelationshipType   string `json:"relationshipType"`
+		RelatedSPDXElement string `json:"relatedSpdxElement"`
+	} `json:"relationships"`
+}
+
+func TestTheSBOMNamesEverythingTheBinariesCarry(t *testing.T) {
+	doc := renderedSBOM(t)
+
+	licences := map[string]string{}
+	for _, p := range doc.Packages {
+		licences[p.Name] = p.LicenseDeclared
+	}
+
+	for _, m := range legal.Modules() {
+		name := m.Path
+		if name == "std" {
+			name = "Go runtime and standard library"
+		}
+		if licences[name] == "" {
+			t.Errorf("the SBOM never names %s, which this project ships", name)
+			continue
+		}
+		if licences[name] != m.SPDX {
+			t.Errorf("the SBOM says %s is %s and the registry says %s", name, licences[name], m.SPDX)
+		}
+	}
+	for _, a := range legal.Assets() {
+		if licences[a.Name] != a.SPDX {
+			t.Errorf("the SBOM says %s is %q and the registry says %s.\n"+
+				"A font that ships and is not in the document is the defect this whole "+
+				"registry exists for.", a.Name, licences[a.Name], a.SPDX)
+		}
+	}
+}
+
+// The command line binary has no toolkit in it, so it has no fonts in it. A
+// document saying otherwise would be describing a file nobody ships - and this
+// is the assertion that catches a renderer attaching everything to everything.
+func TestTheSBOMKeepsTheTwoBinariesApart(t *testing.T) {
+	doc := renderedSBOM(t)
+
+	name := map[string]string{}
+	for _, p := range doc.Packages {
+		name[p.SPDXID] = p.Name
+	}
+	fonts := map[string]bool{}
+	for _, a := range legal.Assets() {
+		fonts[a.Name] = true
+	}
+
+	described := 0
+	for _, r := range doc.Relationships {
+		if r.RelationshipType == "DESCRIBES" {
+			described++
+			continue
+		}
+		if name[r.SPDXElementID] != "tfg" {
+			continue
+		}
+		if fonts[name[r.RelatedSPDXElement]] {
+			t.Errorf("the SBOM says the command line binary carries %q, and it carries no toolkit at all",
+				name[r.RelatedSPDXElement])
+		}
+	}
+	if described != 2 {
+		t.Errorf("the document describes %d packages and this project releases two binaries", described)
+	}
+}
+
+// SPDX has fields a consumer is entitled to find. An empty one is worse than a
+// missing document, because a reader takes it for an answer.
+func TestTheSBOMCarriesTheFieldsSPDXRequires(t *testing.T) {
+	doc := renderedSBOM(t)
+
+	for field, value := range map[string]string{
+		"spdxVersion":       doc.SPDXVersion,
+		"dataLicense":       doc.DataLicense,
+		"SPDXID":            doc.SPDXID,
+		"name":              doc.Name,
+		"documentNamespace": doc.DocumentNamespace,
+		"created":           doc.CreationInfo.Created,
+	} {
+		if value == "" {
+			t.Errorf("the document has no %s, which SPDX requires", field)
+		}
+	}
+	if doc.SPDXVersion != "SPDX-2.3" {
+		t.Errorf("the document says it is %s and these guards were written for SPDX-2.3", doc.SPDXVersion)
+	}
+	if len(doc.CreationInfo.Creators) == 0 {
+		t.Error("the document names nobody as its creator")
+	}
+	for _, p := range doc.Packages {
+		for field, value := range map[string]string{
+			"SPDXID": p.SPDXID, "name": p.Name, "versionInfo": p.VersionInfo,
+			"downloadLocation": p.DownloadLocation, "licenseConcluded": p.LicenseConcluded,
+			"licenseDeclared": p.LicenseDeclared, "copyrightText": p.CopyrightText,
+		} {
+			if value == "" {
+				t.Errorf("the package %q has no %s", p.Name, field)
+			}
+		}
+	}
+}
+
+// The same inputs have to give the same bytes. A release attaches this file and
+// a statement is made about it, so a document that differs every time it is
+// generated is one nobody can check against anything.
+func TestTheSBOMIsTheSameBytesForTheSameInputs(t *testing.T) {
+	first, err := legal.SPDX(sbomInput(t))
+	if err != nil {
+		t.Fatalf("rendering: %v", err)
+	}
+	second, err := legal.SPDX(sbomInput(t))
+	if err != nil {
+		t.Fatalf("rendering again: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Error("two renderings of the same inputs are not the same bytes")
+	}
+}
+
+// sbomInput is the document as a release would ask for it, with the versions
+// read from the build on every system - the Linux only module is why.
+func sbomInput(t *testing.T) legal.Document {
+	t.Helper()
+	window, _ := shipped(t, "../../cmd/tfg-gui")
+	command, _ := shipped(t, "../../cmd/tfg")
+	if len(window) < 5 || len(command) < 2 {
+		t.Skipf("the build reported %d and %d modules, too few to be the real sets", len(window), len(command))
+	}
+	return legal.Document{
+		Version: version.Version,
+		// Fixed rather than the clock, because a guard comparing a document
+		// against itself has to render the same thing twice.
+		Created: "2026-08-28T00:00:00Z",
+		Seed:    "guard",
+		Binaries: []legal.Binary{
+			{Name: "tfg", Modules: command, GoVersion: runtime.Version()},
+			{Name: "tfg-gui", Modules: window, GoVersion: runtime.Version()},
+		},
+	}
+}
+
+func renderedSBOM(t *testing.T) spdxDoc {
+	t.Helper()
+	raw, err := legal.SPDX(sbomInput(t))
+	if err != nil {
+		t.Fatalf("rendering the SBOM: %v", err)
+	}
+	var doc spdxDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("the SBOM is not JSON a consumer can read: %v", err)
+	}
+	if len(doc.Packages) < 10 {
+		t.Fatalf("the document holds %d packages, too few to be the real set", len(doc.Packages))
+	}
+	if !strings.HasPrefix(doc.DocumentNamespace, "https://") {
+		t.Errorf("the namespace is %q, which is not a URI anybody can resolve", doc.DocumentNamespace)
+	}
+	return doc
+}

--- a/internal/guard/sbomgate_test.go
+++ b/internal/guard/sbomgate_test.go
@@ -1,0 +1,164 @@
+package guard
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The scanner guards the registry, not the other way round.
+//
+// internal/legal is the reviewed list of what this project ships and the bill
+// of materials is generated from it, so the question worth asking on every
+// change is the other one: does what we are about to publish contain something
+// that list does not know? It has an answer already - seven fonts and
+// ninety-seven drawings shipped inside the window binary for as long as it
+// existed, named nowhere, because every check here asked about modules.
+
+// runSBOMGate runs the gate over one pair of reports and returns its ending.
+func runSBOMGate(t *testing.T, python string, scan, ours any) int {
+	t.Helper()
+	dir := t.TempDir()
+	scanPath := writeJSON(t, filepath.Join(dir, "scan.json"), scan)
+	oursPath := writeJSON(t, filepath.Join(dir, "ours.json"), ours)
+
+	out, err := exec.Command(python, sbomGatePath(t), scanPath, oursPath).CombinedOutput()
+	if err == nil {
+		return 0
+	}
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) {
+		t.Fatalf("running the gate: %v\n%s", err, out)
+	}
+	t.Logf("gate said:\n%s", out)
+	return exit.ExitCode()
+}
+
+func writeJSON(t *testing.T, path string, value any) string {
+	t.Helper()
+	body, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("building a report: %v", err)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("writing a report: %v", err)
+	}
+	return path
+}
+
+func sbomGatePath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(repoRoot(t), ".github", "scripts", "sbom_gate.py")
+}
+
+// ourDocument is a small document of the shape the generator produces.
+func ourDocument(names ...string) map[string]any {
+	packages := []any{}
+	for _, name := range names {
+		packages = append(packages, map[string]any{"name": name})
+	}
+	return map[string]any{"packages": packages}
+}
+
+func scanOf(names ...string) map[string]any {
+	artifacts := []any{}
+	for _, name := range names {
+		artifacts = append(artifacts, map[string]any{"name": name, "version": "1.0"})
+	}
+	return map[string]any{"artifacts": artifacts, "files": []any{map[string]any{}}}
+}
+
+// A dozen names, because the gate refuses a document too small to be the real
+// one - a registry that lost its contents would otherwise account for nothing
+// and pass everything.
+func enoughNames() []string {
+	names := []string{}
+	for _, n := range []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"} {
+		names = append(names, "github.com/example/"+n)
+	}
+	return names
+}
+
+func TestTheBillOfMaterialsGateRefusesWhatTheRegistryDoesNotKnow(t *testing.T) {
+	python := pythonForGate(t)
+	known := enoughNames()
+
+	if got := runSBOMGate(t, python, scanOf(known...), ourDocument(known...)); got != 0 {
+		t.Errorf("a scan naming only known components ended %d, and everything in it is accounted for", got)
+	}
+
+	// The real shape of the defect this exists for: something ships that no
+	// list knows. zlib is the name the sibling project found this way.
+	dirty := append(append([]string{}, known...), "zlib")
+	if got := runSBOMGate(t, python, scanOf(dirty...), ourDocument(known...)); got != 1 {
+		t.Errorf("a scan naming a component the registry does not know ended %d, and it has to refuse", got)
+	}
+
+	// The runtime and the program itself are not dependencies and must not be
+	// reported as unaccounted, or the gate cries wolf on every run and gets
+	// switched off - which is worse than never having had it.
+	fine := append(append([]string{}, known...), "stdlib", "tfg", "Testing Files Generator")
+	if got := runSBOMGate(t, python, scanOf(fine...), ourDocument(known...)); got != 0 {
+		t.Errorf("a scan naming the runtime and the program itself ended %d, and neither is a dependency", got)
+	}
+}
+
+// A scanner that fell over is not a clean tree. Measured in this repository on
+// 2026-08-27 with a different scanner: it printed four errors, exited zero and
+// wrote a file that was not JSON. A gate reading the exit code would have
+// called that green.
+func TestAnUnusableScanIsNotACleanScan(t *testing.T) {
+	python := pythonForGate(t)
+	known := enoughNames()
+
+	if got := runSBOMGate(t, python, map[string]any{}, ourDocument(known...)); got != 2 {
+		t.Errorf("a scan naming no artifact at all ended %d, and it scanned nothing", got)
+	}
+	if got := runSBOMGate(t, python, scanOf(known...), map[string]any{"packages": []any{}}); got != 2 {
+		t.Errorf("an empty document of our own ended %d, and it would account for nothing", got)
+	}
+
+	dir := t.TempDir()
+	broken := filepath.Join(dir, "scan.json")
+	if err := os.WriteFile(broken, []byte("<ERROR: missing output>"), 0o600); err != nil {
+		t.Fatalf("writing a broken report: %v", err)
+	}
+	ours := writeJSON(t, filepath.Join(dir, "ours.json"), ourDocument(known...))
+	err := exec.Command(python, sbomGatePath(t), broken, ours).Run()
+	if err == nil {
+		t.Error("a report that is not JSON was accepted as a clean scan")
+	}
+}
+
+// And the workflow has to do what the gate assumes: build both binaries, scan
+// what was built, and read the report rather than the scanner's exit code.
+func TestTheWorkflowScansBothBinariesAndReadsTheReport(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join(repoRoot(t), ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Skipf("no workflow here: %v", err)
+	}
+	workflow := string(body)
+
+	for _, want := range []string{
+		"go build -trimpath -o dist/tfg ./cmd/tfg",
+		"go build -trimpath -o dist/tfg-gui ./cmd/tfg-gui",
+		"go run ./internal/legal/cmd/sbom",
+		"python .github/scripts/sbom_gate.py scan.json ours.spdx.json",
+	} {
+		if !strings.Contains(workflow, want) {
+			t.Errorf("the workflow does not run %q.\n"+
+				"A gate nothing triggers is a gate that says nothing, which is the shape this "+
+				"project has already paid for once.", want)
+		}
+	}
+
+	// The window is where the fonts are. A job scanning only the command line
+	// would pass while the thing the registry exists for went unchecked.
+	if !strings.Contains(workflow, "libgl1-mesa-dev") {
+		t.Error("the workflow does not install the headers the window needs, so it cannot have built it")
+	}
+}

--- a/internal/legal/cmd/sbom/main.go
+++ b/internal/legal/cmd/sbom/main.go
@@ -1,0 +1,161 @@
+// Command sbom writes the bill of materials for a release.
+//
+// It is a build tool and never ships: a main package cannot be imported, so it
+// cannot reach a binary by accident, and nothing in cmd/ refers to it.
+//
+// It asks the compiler what each binary links and hands that to the renderer in
+// internal/legal, which joins it with the reviewed licences. The two halves are
+// deliberately separate - the build knows versions and no licences, the
+// registry knows licences and holds no versions - so neither can drift into
+// being a copy of the other.
+//
+// Usage:
+//
+//	go run ./internal/legal/cmd/sbom -seed v0.1.0 -o tfg-0.1.0.spdx.json
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/donislawdev/TestingFilesGenerator/internal/legal"
+	"github.com/donislawdev/TestingFilesGenerator/internal/version"
+)
+
+func main() {
+	out := flag.String("o", "", "write here instead of standard output")
+	seed := flag.String("seed", "", "what makes the document namespace unique, normally the tag")
+	created := flag.String("created", "", "creation time in RFC3339, defaults to now in UTC")
+	flag.Parse()
+
+	stamp := *created
+	if stamp == "" {
+		stamp = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	binaries, err := describeBinaries()
+	if err != nil {
+		fail(err)
+	}
+	document, err := legal.SPDX(legal.Document{
+		Version:  version.Version,
+		Created:  stamp,
+		Seed:     *seed,
+		Binaries: binaries,
+	})
+	if err != nil {
+		fail(err)
+	}
+
+	if *out == "" {
+		if _, err := os.Stdout.Write(document); err != nil {
+			fail(err)
+		}
+		return
+	}
+	// 0600 rather than 0644, and the linter asked for it rather than taste:
+	// this file is written by a build job and read by the same one, and the
+	// copy people download is the release asset rather than this one.
+	if err := os.WriteFile(*out, document, 0o600); err != nil {
+		fail(err)
+	}
+	fmt.Fprintf(os.Stderr, "wrote %s\n", *out)
+}
+
+// describeBinaries asks what each of the two binaries links.
+//
+// CGO is on for both, because with it off the toolkit hides behind build
+// constraints and the window lists as the stub that has no window - a document
+// that would then claim the window ships two libraries.
+func describeBinaries() ([]legal.Binary, error) {
+	var binaries []legal.Binary
+	for _, target := range []struct{ name, path string }{
+		{"tfg", "./cmd/tfg"},
+		{"tfg-gui", "./cmd/tfg-gui"},
+	} {
+		versions, err := linked(target.path)
+		if err != nil {
+			return nil, err
+		}
+		binaries = append(binaries, legal.Binary{
+			Name:      target.name,
+			Modules:   versions,
+			GoVersion: runtime.Version(),
+		})
+	}
+	return binaries, nil
+}
+
+// linked is what one target links on EVERY system this project releases for,
+// rather than on the one running the generator.
+//
+// Measured while writing this, on the generator's own first output: asked on
+// Windows alone the window came back with twenty-seven modules instead of
+// twenty-eight. github.com/rymdport/portal is linked on Linux only, so a
+// document generated on this machine would have shipped without naming it -
+// which is the same trap THIRD-PARTY-NOTICES.md records having fallen into,
+// in almost the same words.
+func linked(target string) (map[string]string, error) {
+	versions := map[string]string{}
+	for _, goos := range []string{"windows", "linux", "darwin"} {
+		found, err := linkedOn(target, goos)
+		if err != nil {
+			return nil, err
+		}
+		if err := merge(versions, found, goos); err != nil {
+			return nil, err
+		}
+	}
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("%s reported no modules at all, which cannot be right", target)
+	}
+	return versions, nil
+}
+
+// merge folds one system's answer into the set, refusing a disagreement rather
+// than picking a side. Two systems reporting different versions of one module
+// is not something one document can describe.
+func merge(into, found map[string]string, goos string) error {
+	for path, moduleVersion := range found {
+		if seen, ok := into[path]; ok && seen != moduleVersion {
+			return fmt.Errorf("%s is %s on %s and %s elsewhere, so one document "+
+				"cannot describe both", path, moduleVersion, goos, seen)
+		}
+		into[path] = moduleVersion
+	}
+	return nil
+}
+
+// linkedOn asks one system. CGO is on because with it off the toolkit hides
+// behind build constraints and the window lists as the stub that has no window.
+func linkedOn(target, goos string) (map[string]string, error) {
+	//nolint:gosec // the command is the go tool and the target is one of the
+	// two literals in describeBinaries - nothing here comes from outside.
+	cmd := exec.Command("go", "list", "-deps", "-f",
+		"{{if .Module}}{{.Module.Path}}@{{.Module.Version}}{{end}}", target)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=1", "GOOS="+goos)
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("asking what %s links on %s: %w", target, goos, err)
+	}
+	versions := map[string]string{}
+	for _, line := range strings.Split(string(out), "\n") {
+		path, moduleVersion, found := strings.Cut(strings.TrimSpace(line), "@")
+		if !found || strings.Contains(path, "donislawdev") {
+			continue
+		}
+		versions[path] = moduleVersion
+	}
+	return versions, nil
+}
+
+func fail(err error) {
+	fmt.Fprintf(os.Stderr, "sbom: %v\n", err)
+	os.Exit(1)
+}

--- a/internal/legal/spdx.go
+++ b/internal/legal/spdx.go
@@ -1,0 +1,239 @@
+// The bill of materials, rendered from the registry rather than scanned out of
+// a build.
+//
+// Both were measured on 2026-08-27 before this was written, and neither half is
+// enough alone. A scanner reading the window binary names all thirty modules
+// with exact versions - Go records them in the executable - and attaches a
+// licence to exactly one of them. The registry carries the licences, the SPDX
+// identifiers and the copyright lines, which are the half no scanner can infer,
+// and it carries the seven fonts and ninety-seven drawings that arrive inside a
+// module and are invisible to any question asked about modules.
+//
+// So the document is generated from the registry, and the scanner's job is to
+// GUARD it: a scan that names something the registry does not account for is a
+// hole in the registry. That direction is the one that has already paid - it is
+// how the fonts were found.
+//
+// A document that omits what it cannot see is worse than no document at all,
+// because it claims to be complete. This one is as complete as the registry,
+// and the registry is held to the build by guards in both directions.
+
+package legal
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Where this project lives. Written here because an SBOM without a download
+// location is a document nobody can act on.
+const repository = "https://github.com/donislawdev/TestingFilesGenerator"
+
+// ourLicence is what this program is under.
+//
+// GPL-3.0-only rather than GPL-3.0-or-later, and that is read from what the
+// project says about itself rather than assumed: the licence notice the program
+// prints says "the GNU General Public License, version 3", the readme badge
+// says GPL-3.0, and no file anywhere offers a later version. The two spellings
+// are different licences to a machine, so guessing the generous one would be
+// publishing a permission nobody granted.
+const ourLicence = "GPL-3.0-only"
+
+// A Binary is one artefact the document describes, and what its build reported.
+type Binary struct {
+	// Name is what the artefact is called - the command, not the file name of
+	// one platform's archive.
+	Name string
+
+	// Modules is what this binary links: module path to the version the build
+	// recorded. The runtime is not in here, because it is not a module - it is
+	// added from GoVersion.
+	Modules map[string]string
+
+	// GoVersion is the toolchain the binary was built with, which is also the
+	// version of the runtime and standard library inside it.
+	GoVersion string
+}
+
+// A Document is everything the renderer needs that is not in the registry.
+//
+// Created and Seed are inputs rather than readings of the clock, and that is
+// deliberate: a generated document that differs every time it is generated
+// cannot be compared with anything, and the two fields SPDX requires are
+// exactly the two a clock would move.
+type Document struct {
+	Version  string // the tool version, without a leading v
+	Created  string // RFC3339, in UTC
+	Seed     string // what makes the namespace unique - a tag is the useful one
+	Binaries []Binary
+}
+
+// SPDX renders the document as SPDX 2.3 JSON.
+func SPDX(d Document) ([]byte, error) {
+	if len(d.Binaries) == 0 {
+		return nil, fmt.Errorf("an SBOM describing no binary describes nothing")
+	}
+	if d.Created == "" || d.Version == "" {
+		return nil, fmt.Errorf("an SBOM needs a version and a creation time, and they are the caller's to supply")
+	}
+
+	doc := spdxDocument{
+		SPDXVersion:       "SPDX-2.3",
+		DataLicense:       "CC0-1.0",
+		SPDXID:            "SPDXRef-DOCUMENT",
+		Name:              "TestingFilesGenerator-" + d.Version,
+		DocumentNamespace: namespace(d),
+		CreationInfo: spdxCreation{
+			Created: d.Created,
+			Creators: []string{
+				"Tool: tfg-sbom",
+				"Organization: DonislawDev",
+			},
+			Comment: "Generated from internal/legal, the reviewed list of what this " +
+				"project ships, with versions read from the build. See internal/legal/spdx.go " +
+				"for why that is the source rather than a scan of the artefact.",
+		},
+	}
+	for _, binary := range d.Binaries {
+		doc.add(binary, d.Version)
+	}
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(out, '\n'), nil
+}
+
+// namespace is unique per document and stable for the same inputs, so two runs
+// on one tag produce the same URI instead of two nobody can correlate.
+func namespace(d Document) string {
+	seed := d.Seed
+	if seed == "" {
+		seed = d.Created
+	}
+	sum := sha256.Sum256([]byte(d.Version + "|" + seed))
+	return fmt.Sprintf("%s/spdx/%s-%x", repository, d.Version, sum[:8])
+}
+
+// add puts one binary in the document, with everything it carries beneath it.
+func (doc *spdxDocument) add(binary Binary, version string) {
+	root := identifier("Package", binary.Name)
+	doc.Packages = append(doc.Packages, spdxPackage{
+		SPDXID:           root,
+		Name:             binary.Name,
+		VersionInfo:      version,
+		DownloadLocation: repository,
+		FilesAnalyzed:    false,
+		LicenseConcluded: ourLicence,
+		LicenseDeclared:  ourLicence,
+		CopyrightText:    "Copyright (C) 2026 DonislawDev",
+	})
+	doc.Relationships = append(doc.Relationships, spdxRelationship{
+		SPDXElementID:      "SPDXRef-DOCUMENT",
+		RelationshipType:   "DESCRIBES",
+		RelatedSPDXElement: root,
+	})
+	for _, item := range carriedBy(binary) {
+		doc.contain(root, item)
+	}
+}
+
+// contain adds one component and the relationship saying which binary has it.
+//
+// The same component in two binaries is one package with two relationships,
+// which is what SPDX means by containment - repeating the package would say
+// the two binaries carry different copies of it.
+func (doc *spdxDocument) contain(root string, item Item) {
+	id := identifier("Package", item.Name)
+	if !doc.has(id) {
+		doc.Packages = append(doc.Packages, spdxPackage{
+			SPDXID:           id,
+			Name:             item.Name,
+			VersionInfo:      orNoAssertion(item.Version),
+			DownloadLocation: "NOASSERTION",
+			FilesAnalyzed:    false,
+			LicenseConcluded: item.SPDX,
+			LicenseDeclared:  item.SPDX,
+			CopyrightText:    orNoAssertion(item.Copyright),
+			ExternalRefs:     externalRefs(item),
+		})
+	}
+	doc.Relationships = append(doc.Relationships, spdxRelationship{
+		SPDXElementID:      root,
+		RelationshipType:   "CONTAINS",
+		RelatedSPDXElement: id,
+	})
+}
+
+func (doc *spdxDocument) has(id string) bool {
+	for _, p := range doc.Packages {
+		if p.SPDXID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// carriedBy is what one binary contains, in the order the list is printed.
+func carriedBy(binary Binary) []Item {
+	reviewed := map[string]Module{}
+	for _, m := range modules {
+		reviewed[m.Path] = m
+	}
+	items := []Item{moduleItem(runtimeName, binary.GoVersion, reviewed)}
+	paths := make([]string, 0, len(binary.Modules))
+	for path := range binary.Modules {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		if _, known := reviewed[path]; !known {
+			continue
+		}
+		items = append(items, moduleItem(path, binary.Modules[path], reviewed))
+	}
+	return append(items, embeddedItems(linkedSet(binary.Modules))...)
+}
+
+func linkedSet(versions map[string]string) map[string]bool {
+	linked := map[string]bool{}
+	for path := range versions {
+		linked[path] = true
+	}
+	return linked
+}
+
+// externalRefs carries the package URL, which is how a machine looks a module
+// up. Only modules have one - a font inside a module is not a package anybody
+// can fetch.
+func externalRefs(item Item) []spdxExternalRef {
+	if item.Embedded || item.Version == "" || !strings.Contains(item.Name, "/") {
+		return nil
+	}
+	return []spdxExternalRef{{
+		ReferenceCategory: "PACKAGE-MANAGER",
+		ReferenceType:     "purl",
+		ReferenceLocator:  "pkg:golang/" + item.Name + "@" + item.Version,
+	}}
+}
+
+func orNoAssertion(value string) string {
+	if value == "" {
+		return "NOASSERTION"
+	}
+	return value
+}
+
+// notIdentifier is everything the SPDX identifier grammar does not allow. It
+// permits letters, digits, dots and hyphens, and a module path is full of
+// slashes.
+var notIdentifier = regexp.MustCompile(`[^A-Za-z0-9.-]`)
+
+// identifier builds an SPDXRef that follows that grammar.
+func identifier(kind, name string) string {
+	return "SPDXRef-" + kind + "-" + strings.Trim(notIdentifier.ReplaceAllString(name, "-"), "-")
+}

--- a/internal/legal/spdxtypes.go
+++ b/internal/legal/spdxtypes.go
@@ -1,0 +1,59 @@
+// The shape of an SPDX 2.3 document, as structs rather than as maps.
+//
+// Structs because the field order of a marshalled struct is the order they are
+// declared in, so the same inputs render the same bytes - and a document that
+// differs every time it is generated cannot be compared with anything. Maps
+// would sort their keys, which is also stable, but says nothing about which
+// fields exist.
+//
+// Only the fields this project fills are here. SPDX has more, and a field
+// carrying NOASSERTION everywhere is noise that reads like information.
+
+package legal
+
+type spdxDocument struct {
+	SPDXVersion       string             `json:"spdxVersion"`
+	DataLicense       string             `json:"dataLicense"`
+	SPDXID            string             `json:"SPDXID"`
+	Name              string             `json:"name"`
+	DocumentNamespace string             `json:"documentNamespace"`
+	CreationInfo      spdxCreation       `json:"creationInfo"`
+	Packages          []spdxPackage      `json:"packages"`
+	Relationships     []spdxRelationship `json:"relationships"`
+}
+
+type spdxCreation struct {
+	Created  string   `json:"created"`
+	Creators []string `json:"creators"`
+	Comment  string   `json:"comment,omitempty"`
+}
+
+type spdxPackage struct {
+	SPDXID           string `json:"SPDXID"`
+	Name             string `json:"name"`
+	VersionInfo      string `json:"versionInfo"`
+	DownloadLocation string `json:"downloadLocation"`
+
+	// False, and deliberately. This describes components rather than the
+	// individual files they arrive as, and claiming otherwise would oblige the
+	// document to list and checksum every file. A half filled file list reads
+	// as a complete one.
+	FilesAnalyzed bool `json:"filesAnalyzed"`
+
+	LicenseConcluded string            `json:"licenseConcluded"`
+	LicenseDeclared  string            `json:"licenseDeclared"`
+	CopyrightText    string            `json:"copyrightText"`
+	ExternalRefs     []spdxExternalRef `json:"externalRefs,omitempty"`
+}
+
+type spdxExternalRef struct {
+	ReferenceCategory string `json:"referenceCategory"`
+	ReferenceType     string `json:"referenceType"`
+	ReferenceLocator  string `json:"referenceLocator"`
+}
+
+type spdxRelationship struct {
+	SPDXElementID      string `json:"spdxElementId"`
+	RelationshipType   string `json:"relationshipType"`
+	RelatedSPDXElement string `json:"relatedSpdxElement"`
+}


### PR DESCRIPTION
## What changes

An SPDX 2.3 document generated from `internal/legal` - 38 packages, two roots, one per binary - and a CI gate that turns a scanner around: it asks whether the **built binaries** contain something the registry does not know.

## Why not just scan

Measured on 2026-08-27: syft reading the window binary names all thirty modules with exact versions - Go records them in the executable - and attaches a licence to **one** of them. It also cannot see a font, because a font is a file inside a module.

So the inventory half is free and the licence half is the registry's. A document that omits what it cannot see is worse than none, because it claims to be complete.

## The generator caught its own first mistake

Asked on Windows alone it produced **27 modules instead of 28**: `github.com/rymdport/portal` is linked on Linux only. It asks all three systems now, and refuses when two of them report different versions. `THIRD-PARTY-NOTICES.md` records falling into that same trap, in almost the same words.

## The gate

`anchore/sbom-action` (pinned by commit) scans both built binaries, and `.github/scripts/sbom_gate.py` compares the scan with our document. Proven in three directions before it was wired in:

| case | ending |
|---|---|
| every component accounted for | 0 |
| a component the registry does not know (`zlib`) | 1 |
| a report that is empty or not JSON | 2 |

The third is not hypothetical: a different scanner in this repository printed four errors, exited 0 and wrote a 23 byte file that was not JSON.

The job is called **bill of materials** and does not block merging until its name is added to the required contexts in the ruleset.

## Guards

Seven, seven mutations, all caught. The document is checked for completeness against the registry, for keeping the two binaries apart (the command line carries no fonts and the document must not say it does), for the fields SPDX requires, and for producing **the same bytes for the same inputs** - which matters because a release attaches this file and an attestation is a statement about its bytes.

## Where the guards caught this work

The depth ceiling, the layer map, the doc comment guard, `errorlint` and `gosec` all went red while this was being written. Nothing was raised or disabled: the code was flattened, the package declared, a comment moved, file permissions tightened, and one `//nolint` written with its reason where `internal/oracle` already had that pattern.

## Note on a reversal

`docs/PROVENANCE-PLAN.md` §6 recommended committing the document and comparing it with a guard. SPDX requires `created` and `documentNamespace`, so a committed file would either lie about a date or churn on every regeneration. It is generated at release time instead, from inputs that are guarded. The reasoning is written into §13 of that document rather than quietly changed.

## Checked

`go test ./...` exit 0, `python tools/preflight.py --quick` 11 of 11, and `syft convert` reads our document back.