### PR TITLE
Every published file says where it came from and what is inside it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,13 +269,41 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: write
+      # The two the attestation steps need and nothing else grants. id-token
+      # mints the short lived OIDC token that signs the statement, attestations
+      # writes the result to this repository's store. A release without them
+      # would still publish - it would just publish nothing anybody can check.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: incoming
           merge-multiple: true
+
+      - name: what is inside what we are publishing
+        # The bill of materials, generated from internal/legal - the reviewed
+        # list of what this project ships - with the versions read from the
+        # build. Not from a scan of the artefact: measured 2026-08-27, a scan of
+        # the window binary names every module with an exact version and
+        # attaches a licence to one of thirty.
+        #
+        # The tag seeds the document namespace, so re-running this workflow on
+        # one tag produces the same URI rather than a fresh random one nobody
+        # can correlate.
+        run: |
+          set -euo pipefail
+          version="${{ needs.check.outputs.version }}"
+          go run ./internal/legal/cmd/sbom \
+            -seed "${GITHUB_REF_NAME}" \
+            -o "incoming/tfg_${version}.spdx.json"
+          echo "SBOM=incoming/tfg_${version}.spdx.json" >> "$GITHUB_ENV"
 
       - name: one list of what is being published
         run: |
@@ -286,6 +314,59 @@ jobs:
           # one more thing between them and an answer.
           sha256sum -- * > SHA256SUMS.txt
           cat SHA256SUMS.txt
+
+      # WHO built it, and FROM WHAT. This says the files came out of this
+      # repository, from this commit, through this workflow, on a GitHub hosted
+      # runner - signed with a short lived identity and recorded in a public
+      # log. A user checks it with one command:
+      #
+      #     gh attestation verify tfg_<version>_linux_amd64.tar.gz \
+      #        -R donislawdev/TestingFilesGenerator
+      #
+      # It is a different question from a code signature, which is why both are
+      # worth having: a signature says who vouches for the file, provenance says
+      # which source and which build produced it. A stolen key cannot forge
+      # this, and a fork cannot claim to be this repository.
+      #
+      # subject-checksums rather than a glob: the file it reads is the one the
+      # release publishes, so the statement covers exactly what is on the page,
+      # under the names people download.
+      #
+      # 🔴 When signing arrives, this moves. A signature changes the bytes, and
+      # a statement about the wrong bytes verifies against nothing - so the
+      # signed archive gets its own attestation after the signing ritual, and
+      # this one stays here describing what this workflow actually built.
+      - name: attest what this build produced
+        id: provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
+        with:
+          subject-checksums: incoming/SHA256SUMS.txt
+
+      # WHAT IS INSIDE. A separate statement from a separate action on purpose:
+      # the one above builds its predicate from the workflow's own context and
+      # there is nothing to hand it, while this one carries a document we
+      # generated. Two questions, two answers.
+      - name: attest what is inside it
+        id: sbom
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6  # v4.2.2
+        with:
+          subject-checksums: incoming/SHA256SUMS.txt
+          sbom-path: ${{ env.SBOM }}
+
+      - name: publish the statements beside the files
+        # As RELEASE ASSETS, not only in the attestation store. Scorecard reads
+        # assets by file extension and never opens that store, and a person
+        # behind a proxy that blocks the API cannot use it either. With the
+        # bundle beside the archive, "gh attestation verify <file> --bundle
+        # <bundle>" answers offline, from a mirror, from anywhere.
+        run: |
+          set -euo pipefail
+          version="${{ needs.check.outputs.version }}"
+          cp "${{ steps.provenance.outputs.bundle-path }}" \
+             "incoming/tfg_${version}.provenance.sigstore.json"
+          cp "${{ steps.sbom.outputs.bundle-path }}" \
+             "incoming/tfg_${version}.sbom.sigstore.json"
+          ls -l incoming
 
       - name: notes
         run: |
@@ -312,6 +393,20 @@ jobs:
             echo
             echo "If that is not a trade you want to make, build from source - it takes one command"
             echo "and the readme has it."
+            echo
+            echo "## What you can check"
+            echo
+            echo "Every file here carries two statements made when it was built: where it came from,"
+            echo "and what is inside it. Both are signed by the build itself, and neither needs a"
+            echo "certificate from us."
+            echo
+            echo "\`\`\`"
+            echo "gh attestation verify <the file you downloaded> -R ${GITHUB_REPOSITORY}"
+            echo "\`\`\`"
+            echo
+            echo "The \`.spdx.json\` file lists every library and every font compiled into these"
+            echo "binaries, with its licence. The \`.sigstore.json\` files are the statements"
+            echo "themselves, so the command above also works offline with \`--bundle\`."
             echo
             echo "## Everything that changed"
             echo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,25 @@ because it turns other people's test suites red.
 
 ### Added
 
+- Every file in a release now carries two statements made while it was built:
+  where it came from, and what is inside it. Both are signed by the build with
+  a short lived identity and written to a public log, so anybody can check a
+  download without having to trust this page:
+
+  ```
+  gh attestation verify <the file you downloaded> -R donislawdev/TestingFilesGenerator
+  ```
+
+  A release also carries `tfg_<version>.spdx.json`, a bill of materials naming
+  every library and every font compiled into these binaries, with its licence.
+  The statements themselves are published beside the downloads, so the command
+  above works offline with `--bundle` as well.
+
+  The binaries are still not signed and the notes still say so. Provenance
+  answers a different question from a signature: which source and which build
+  produced a file, rather than who vouches for it. It does not stop Windows or
+  macOS from warning about an unsigned program.
+
 - `tfg license` now lists what the binary in front of you actually carries:
   every module compiled into it, with its version and its licence, and the
   fonts and drawings that arrive inside those modules. It used to point at

--- a/internal/guard/attestation_test.go
+++ b/internal/guard/attestation_test.go
@@ -1,0 +1,157 @@
+package guard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+)
+
+// A release says two things about itself that nobody has to take on trust:
+// where the files came from, and what is inside them.
+//
+// Neither is a code signature and neither pretends to be. A signature says who
+// vouches for a file. Provenance says which source and which build produced it,
+// signed with an identity that lives for minutes and recorded in a public log,
+// so a stolen key cannot forge it and a fork cannot claim to be this
+// repository. The binaries are unsigned and the release notes say so.
+//
+// The whole point is that a person can check it, so these guards ask whether
+// the release actually makes the statements and actually publishes them.
+
+// publishJob is the part of the release workflow these guards read.
+type publishJob struct {
+	Permissions map[string]string `yaml:"permissions"`
+	Steps       []struct {
+		Name string            `yaml:"name"`
+		Uses string            `yaml:"uses"`
+		With map[string]any    `yaml:"with"`
+		Run  string            `yaml:"run"`
+		Env  map[string]string `yaml:"env"`
+	} `yaml:"steps"`
+}
+
+func releasePublishJob(t *testing.T) publishJob {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(repoRoot(t), ".github", "workflows", "release.yml"))
+	if err != nil {
+		t.Skipf("no release workflow here: %v", err)
+	}
+	var workflow struct {
+		Jobs map[string]publishJob `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(body, &workflow); err != nil {
+		t.Fatalf("reading the release workflow: %v", err)
+	}
+	job, ok := workflow.Jobs["publish"]
+	if !ok {
+		t.Fatal("the release workflow has no publish job, so nothing here could have been checked")
+	}
+	return job
+}
+
+// The two permissions nothing else grants. Without them the steps below do not
+// fail loudly - they cannot mint a token, and a release would go out carrying
+// no statement at all while every other job stayed green.
+func TestTheReleaseAsksForWhatAnAttestationNeeds(t *testing.T) {
+	job := releasePublishJob(t)
+	for _, permission := range []string{"id-token", "attestations"} {
+		if job.Permissions[permission] != "write" {
+			t.Errorf("the publish job does not ask for %s: write, and an attestation cannot be made without it",
+				permission)
+		}
+	}
+	if job.Permissions["contents"] != "write" {
+		t.Error("the publish job cannot write the release itself any more")
+	}
+}
+
+// Two statements, two actions, and each over the files the release actually
+// publishes rather than over a glob that might match something else.
+func TestTheReleaseAttestsEveryFileItPublishes(t *testing.T) {
+	job := releasePublishJob(t)
+
+	wanted := map[string]bool{
+		"actions/attest-build-provenance": false,
+		"actions/attest":                  false,
+	}
+	for _, step := range job.Steps {
+		action, _, _ := strings.Cut(step.Uses, "@")
+		if _, want := wanted[action]; !want {
+			continue
+		}
+		wanted[action] = true
+		// The list of checksums is the list the release publishes, so the
+		// statement covers exactly what is on the page, under the names people
+		// download. A glob would cover whatever happened to be in the
+		// directory.
+		if got, _ := step.With["subject-checksums"].(string); got != "incoming/SHA256SUMS.txt" {
+			t.Errorf("%s attests %q rather than the checksums of what is published", action, got)
+		}
+	}
+	for action, found := range wanted {
+		if !found {
+			t.Errorf("the release never runs %s, so it publishes files nobody can check", action)
+		}
+	}
+}
+
+// The document has to be generated and the statements have to end up beside the
+// downloads. An attestation only in the store is one a person behind a proxy
+// cannot reach, and Scorecard reads assets by extension and never opens it.
+func TestTheReleasePublishesItsDocumentAndItsStatements(t *testing.T) {
+	job := releasePublishJob(t)
+
+	var script strings.Builder
+	sbomAttested := false
+	for _, step := range job.Steps {
+		script.WriteString(step.Run)
+		script.WriteString("\n")
+		if _, ok := step.With["sbom-path"]; ok {
+			sbomAttested = true
+		}
+	}
+	all := script.String()
+
+	for what, want := range map[string]string{
+		"the bill of materials is generated":             "go run ./internal/legal/cmd/sbom",
+		"it is written where the release publishes from": "-o \"incoming/tfg_${version}.spdx.json\"",
+		"the provenance bundle becomes an asset":         "provenance.sigstore.json",
+		"the sbom bundle becomes an asset":               "sbom.sigstore.json",
+	} {
+		if !strings.Contains(all, want) {
+			t.Errorf("%s: the publish job never runs %q", what, want)
+		}
+	}
+	if !sbomAttested {
+		t.Error("no step attests the bill of materials, so the document travels unsigned")
+	}
+}
+
+// And the notes tell somebody how to use any of it. A statement nobody knows
+// about is a statement nobody checks.
+func TestTheReleaseNotesSayHowToCheckWhatWasDownloaded(t *testing.T) {
+	job := releasePublishJob(t)
+	var notes string
+	for _, step := range job.Steps {
+		if step.Name == "notes" {
+			notes = step.Run
+		}
+	}
+	if notes == "" {
+		t.Fatal("the publish job writes no notes, so there was nothing to read")
+	}
+	for _, want := range []string{"gh attestation verify", "spdx.json"} {
+		if !strings.Contains(notes, want) {
+			t.Errorf("the release notes never mention %q", want)
+		}
+	}
+	// The binaries are still unsigned, and the notes have said so since the
+	// first release. Provenance is a different question and must not be read
+	// as an answer to that one.
+	if !strings.Contains(notes, "not signed") {
+		t.Error("the release notes stopped saying the binaries are unsigned, which is still true")
+	}
+}


### PR DESCRIPTION
⚠️ **This one has to be merged from the browser** - it touches `.github/workflows/**` and the `gh` token has no `workflow` scope.

## What changes

The publish job makes two statements about what it puts on the release page:

- **provenance** - the files came out of this repository, from this commit, through this workflow, on a GitHub hosted runner
- **the bill of materials** - the SPDX document generated from the licence registry, signed rather than left as a file somebody could swap

Both over `incoming/SHA256SUMS.txt` rather than a glob, so the subjects are exactly what the release publishes, under the names people download. Both bundles become release assets as well as store entries: verification from behind a proxy, from a mirror or offline is the case that matters, and Scorecard reads assets by extension and never opens that store.

A release now also carries `tfg_<version>.spdx.json`.

## What this is not

It is **not a code signature** and the notes still say the binaries are unsigned. Provenance answers which source and which build produced a file, not who vouches for it. It does not stop SmartScreen or Gatekeeper.

A guard checks that sentence is still there, so provenance cannot quietly be read as an answer to a question it does not answer.

## Written to be moved

When signing arrives, the signature **changes the bytes**, and a statement about the wrong bytes verifies against nothing. So the provenance stays here describing what this workflow built, and the SBOM attestation moves after the signing ritual - the same split `BeanNetworkTester` uses. The comment at that step says so, so nobody has to work it out twice.

## Guards

Four, four mutations, all caught. One exists because the failure is silent: without `id-token: write` and `attestations: write` the steps mint nothing, the release still goes out, and every other job stays green.

## Checked

`go test ./...` exit 0, `python tools/preflight.py --quick` 11 of 11. The site guard reads `release.yml` for its download matrix and was run explicitly - it is unaffected, which was reasoning before and is a measurement now.