### PR TITLE
The build hands itself over, and a person with the card signs it

### DIFF
--- a/.github/scripts/sign_release.py
+++ b/.github/scripts/sign_release.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Sign the Windows binaries of a release with the card, then hand it back.
+
+    python .github/scripts/sign_release.py v0.2.0
+    python .github/scripts/sign_release.py v0.2.0 --dry-run   # everything but sign and upload
+
+Why this is a step a person runs
+--------------------------------
+The signing key lives on a cryptographic card in a USB reader and cannot be
+exported - that is the whole value of it - so no GitHub hosted runner can ever
+reach it. A self hosted runner could, and this is a PUBLIC repository, where a
+self hosted runner is a machine strangers can aim a pull request at. So the build
+happens where builds belong and the signature happens where the card is, and this
+script is the seam between them.
+
+What it does, in order, and what it refuses
+-------------------------------------------
+ 1. downloads the unsigned build the release workflow produced for this tag;
+ 2. **verifies that build's provenance** before touching it. Signing something
+    you did not check is how a supply chain gets a signature on it;
+ 3. signs the three Windows programs with the card, each with an RFC 3161
+    timestamp - **without a timestamp a signature dies when the certificate
+    expires**, and this one expires in 2027;
+ 4. reads the certificate back OUT of each signed file and refuses to go on
+    unless it hashes to the pin in internal/legal. A second code signing
+    certificate on the same machine - a renewal, a test one, one from another
+    project - signs just as willingly and the release page looks identical;
+ 5. repacks those three archives and writes SHA256SUMS.txt over everything it is
+    about to publish, signed and unsigned alike;
+ 6. uploads the lot to the DRAFT release and asks attest-release.yml for the
+    statement about the signed bytes;
+ 7. waits for that statement and confirms the draft is complete. Until this
+    existed in the project this came from, the script ended at "dispatched, go
+    look" - and a draft missing one file looks almost exactly like a finished one.
+
+Nothing here publishes. The release stays a draft until a person reads it and
+presses the button.
+"""
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import zipfile
+
+REPO = "donislawdev/TestingFilesGenerator"
+ATTEST_WORKFLOW = "attest-release.yml"
+TIMESTAMP_URL = "http://time.certum.pl/"
+
+# The programs that get a signature. Everything else in the build travels
+# untouched: a Linux or a macOS archive is the finished article here, and the
+# statement the build made about it stays true because its bytes do not move.
+SIGNED_ARCHIVES = ("windows_amd64.zip", "windows_arm64.zip")
+
+# Where the pin lives. Read out of the Go source rather than copied here,
+# because two written copies of one digest is exactly the drift this pin exists
+# to catch.
+PIN_FILE = os.path.join("internal", "legal", "codesign.go")
+
+# The OID, not the display name. Measured on this machine on 2026-08-28:
+# filtering certificates by the friendly name "Code Signing" returns NOTHING on
+# a Polish Windows, which calls it "Podpisywanie kodu" - and the script would
+# then report a missing card while the card was plugged in and working.
+CODE_SIGNING_OID = "1.3.6.1.5.5.7.3.3"
+
+
+def run(argv, **kw):
+    """Run something and let it print. A failure raises."""
+    print("    $ %s" % " ".join(str(a) for a in argv))
+    return subprocess.run(argv, check=True, **kw)
+
+
+def powershell(script):
+    out = subprocess.run(
+        ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
+        capture_output=True, text=True)
+    if out.returncode != 0:
+        raise SystemExit("sign_release: powershell failed:\n%s" % out.stderr.strip())
+    return out.stdout
+
+
+def pinned_digest():
+    """The certificate digest this project signs with, read from the Go source."""
+    with open(PIN_FILE, encoding="utf-8") as handle:
+        body = handle.read()
+    found = re.search(r'CodeSigningSHA256 = "([0-9a-f]{64})"', body)
+    if not found:
+        raise SystemExit("sign_release: no pinned certificate digest in %s" % PIN_FILE)
+    return found.group(1)
+
+
+def find_signtool():
+    """The newest x64 signtool.exe from the Windows SDK, or a clear refusal."""
+    kits = r"C:\Program Files (x86)\Windows Kits\10\bin"
+    if os.path.isdir(kits):
+        for version in sorted(os.listdir(kits), reverse=True):
+            candidate = os.path.join(kits, version, "x64", "signtool.exe")
+            if os.path.isfile(candidate):
+                return candidate
+    raise SystemExit(
+        "sign_release: no signtool.exe under %s - install the Windows SDK "
+        "(the Signing Tools component is enough)." % kits)
+
+
+def expiry_notice(not_after, now):
+    """What to say about a certificate that will not last forever."""
+    if not not_after:
+        return ["  the certificate does not say when it expires"]
+    try:
+        when = datetime.datetime.fromisoformat(str(not_after).replace("Z", "+00:00"))
+    except ValueError:
+        return ["  cannot read the expiry date: %s" % not_after]
+    if when.tzinfo:
+        when = when.replace(tzinfo=None)
+    days = (when - now).days
+    if days < 0:
+        raise SystemExit(
+            "sign_release: the certificate expired on %s. Nothing can be signed with it.\n"
+            "A renewal is a DIFFERENT certificate, so internal/legal/codesign.go has to "
+            "move with it." % when.date())
+    if days < 90:
+        return ["  %d days left on this certificate." % days,
+                "     A renewal is a DIFFERENT certificate, so the pin in "
+                "internal/legal/codesign.go goes with it."]
+    return ["  %d days left on this certificate" % days]
+
+
+def signing_thumbprint(pin):
+    """The SHA-1 thumbprint of the certificate whose DER bytes hash to the pin.
+
+    Two digests, one source of truth. signtool selects by SHA-1 because that is
+    the only selector it takes, and the repository pins SHA-256 because that is
+    the digest worth pinning. Resolving one to the other here means the two can
+    never drift apart in a configuration file.
+    """
+    script = (
+        "$out = @(); "
+        "Get-ChildItem Cert:\\CurrentUser\\My, Cert:\\LocalMachine\\My "
+        "-ErrorAction SilentlyContinue | Where-Object { "
+        "  $_.Extensions.EnhancedKeyUsages.Value -contains '%s' } | ForEach-Object { "
+        "  $h = [System.Security.Cryptography.SHA256]::Create().ComputeHash($_.RawData); "
+        "  $out += [pscustomobject]@{ "
+        "    sha256 = (($h | ForEach-Object { $_.ToString('x2') }) -join ''); "
+        "    thumb = $_.Thumbprint; subject = $_.Subject; "
+        "    notAfter = $_.NotAfter.ToString('s') } "
+        "}; $out | ConvertTo-Json -Compress" % CODE_SIGNING_OID
+    )
+    entries = json.loads(powershell(script).strip() or "[]")
+    if isinstance(entries, dict):
+        entries = [entries]
+    for entry in entries:
+        if entry.get("sha256") == pin:
+            # The common name only. The rest of the subject carries the owner's
+            # town and region, and printing it into a terminal somebody pastes
+            # into a chat helps nobody.
+            print("  certificate: %s" % entry.get("subject", "").split(",")[0])
+            for line in expiry_notice(entry.get("notAfter"), datetime.datetime.now()):
+                print(line)
+            return entry["thumb"]
+    raise SystemExit(
+        "sign_release: the pinned certificate (%s...) is not in the Windows store.\n"
+        "Plug in the card reader and check the card manager can see it. If the "
+        "certificate was renewed, internal/legal/codesign.go has to move with it."
+        % pin[:16])
+
+
+def certificate_of(path):
+    """The sha256 of the certificate that actually signed a file."""
+    script = (
+        "$s = Get-AuthenticodeSignature -LiteralPath '%s'; "
+        "if ($s.Status -ne 'Valid') { Write-Error ('signature status: ' + $s.Status); exit 1 }; "
+        "$h = [System.Security.Cryptography.SHA256]::Create()"
+        ".ComputeHash($s.SignerCertificate.RawData); "
+        "(($h | ForEach-Object { $_.ToString('x2') }) -join '')" % path
+    )
+    return powershell(script).strip()
+
+
+def sha256_of(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def gh_json(*args):
+    out = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if out.returncode != 0:
+        raise SystemExit("sign_release: gh %s failed:\n%s" % (args[0], out.stderr.strip()))
+    return json.loads(out.stdout or "null")
+
+
+# --------------------------------------------------------------------------- #
+# the phases
+# --------------------------------------------------------------------------- #
+
+def fetch_build(tag, into):
+    """The build the release workflow made for this tag.
+
+    A missing artefact is the ordinary case rather than a crash: the tag has
+    not been pushed, or the build is still running, or it failed. Saying so
+    beats a traceback, because the person reading it is holding a card reader
+    and wondering which half of this is broken.
+    """
+    if os.path.isdir(into):
+        shutil.rmtree(into)
+    os.makedirs(into)
+    try:
+        run(["gh", "run", "download", "--repo", REPO, "--name",
+             "unsigned-build-%s" % tag, "--dir", into])
+    except subprocess.CalledProcessError:
+        raise SystemExit(
+            "sign_release: there is no build called unsigned-build-%s.\n"
+            "Either the tag has not been pushed, or release.yml has not finished, "
+            "or it failed. Look at the run before signing anything." % tag)
+    names = sorted(os.listdir(into))
+    print("  %d file(s): %s" % (len(names), ", ".join(names)))
+    return names
+
+
+def verify_before_touching(directory):
+    """Refuse to sign a build whose own statement does not check out.
+
+    This is the step that makes the rest worth anything. Signing something
+    you did not check is how a supply chain gets a signature on it - the whole
+    attack is to hand the person with the key something that is not what they
+    think it is.
+    """
+    bundle = os.path.join(directory, "build.provenance.sigstore.json")
+    if not os.path.isfile(bundle):
+        raise SystemExit(
+            "sign_release: the build carries no provenance bundle, so there is "
+            "nothing to check it against. Do not sign it.")
+    archives = [n for n in sorted(os.listdir(directory))
+                if n.endswith(".zip") or n.endswith(".tar.gz")]
+    if not archives:
+        raise SystemExit("sign_release: the build carries no archives at all")
+    for name in archives:
+        run(["gh", "attestation", "verify", os.path.join(directory, name),
+             "-R", REPO, "--bundle", bundle])
+    print("  %d archive(s) verified against the build's own statement" % len(archives))
+
+
+def windows_archives(directory):
+    """The archives that get a signature, refusing a surprise in the count."""
+    found = [n for n in sorted(os.listdir(directory))
+             if any(n.endswith(suffix) for suffix in SIGNED_ARCHIVES)]
+    if len(found) != 3:
+        raise SystemExit(
+            "sign_release: expected three Windows archives to sign and found %d: %s\n"
+            "Two command line builds and one window build carry a Windows program. "
+            "Signing two of three would publish an unsigned binary next to signed ones."
+            % (len(found), ", ".join(found) or "none"))
+    return found
+
+
+def sign_archive(path, thumbprint, pin, signtool, dry_run):
+    """Sign the program inside one archive and put the archive back together."""
+    work = path + ".unpacked"
+    if os.path.isdir(work):
+        shutil.rmtree(work)
+    os.makedirs(work)
+    with zipfile.ZipFile(path) as archive:
+        archive.extractall(work)
+    programs = [n for n in sorted(os.listdir(work)) if n.endswith(".exe")]
+    if len(programs) != 1:
+        raise SystemExit("sign_release: %s holds %d programs, expected one"
+                         % (os.path.basename(path), len(programs)))
+    program = os.path.join(work, programs[0])
+
+    command = [signtool, "sign", "/sha1", thumbprint, "/fd", "sha256",
+               "/tr", TIMESTAMP_URL, "/td", "sha256", "/v", program]
+    if dry_run:
+        print("    DRY RUN, would run: %s" % " ".join(command))
+    else:
+        run(command)
+        run([signtool, "verify", "/pa", "/v", program])
+        actual = certificate_of(program)
+        if actual != pin:
+            raise SystemExit(
+                "sign_release: %s was signed by a DIFFERENT certificate\n"
+                "  expected %s\n  got      %s\nNothing has been uploaded."
+                % (programs[0], pin, actual))
+
+    os.remove(path)
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name in sorted(os.listdir(work)):
+            archive.write(os.path.join(work, name), name)
+    shutil.rmtree(work)
+    print("    %s: %s signed and repacked" % (os.path.basename(path), programs[0]))
+
+
+def name_for_publication(directory, tag):
+    """Give the build's own files the names a person will see, or drop them.
+
+    build.sha256 was the subject list for the statement the runner made. It
+    describes three archives that no longer exist in that form, so publishing it
+    beside SHA256SUMS.txt would put two lists of checksums on one page and one of
+    them would be wrong about half the files.
+
+    The provenance bundle does stay, under a name a person can use: it still
+    describes the five archives nothing signed, byte for byte.
+    """
+    build_sums = os.path.join(directory, "build.sha256")
+    if os.path.isfile(build_sums):
+        os.remove(build_sums)
+    made = os.path.join(directory, "build.provenance.sigstore.json")
+    if os.path.isfile(made):
+        os.rename(made, os.path.join(
+            directory, "tfg_%s.provenance.sigstore.json" % tag.lstrip("v")))
+
+
+def write_checksums(directory):
+    """SHA256SUMS.txt over what is about to be published, and its own digest."""
+    published = sorted(os.listdir(directory))
+    lines = []
+    for name in published:
+        lines.append("%s  %s\n" % (sha256_of(os.path.join(directory, name)), name))
+    sums = os.path.join(directory, "SHA256SUMS.txt")
+    with open(sums, "w", encoding="utf-8", newline="\n") as handle:
+        handle.writelines(lines)
+    print("  %d file(s) listed in SHA256SUMS.txt" % len(published))
+    return sha256_of(sums)
+
+
+def upload_to_draft(tag, directory, dry_run):
+    """Everything a person downloads, onto the draft."""
+    files = [os.path.join(directory, n) for n in sorted(os.listdir(directory))
+             if not n.endswith(".unpacked")]
+    if dry_run:
+        print("  DRY RUN, would upload %d file(s)" % len(files))
+        return
+    run(["gh", "release", "upload", tag, "--repo", REPO, "--clobber", *files])
+
+
+def ask_for_the_statement(tag, digest, dry_run):
+    """Hand the signed bytes back to a workflow, which can sign a statement."""
+    if dry_run:
+        print("  DRY RUN, would dispatch %s for %s" % (ATTEST_WORKFLOW, digest[:16]))
+        return
+    run(["gh", "workflow", "run", ATTEST_WORKFLOW, "--repo", REPO,
+         "-f", "tag=%s" % tag, "-f", "digest=%s" % digest])
+
+
+def confirm_draft(tag, wait_seconds, dry_run):
+    """Wait for the statement and check the draft is actually complete.
+
+    Without this the script ends at "dispatched, go look" - and a draft
+    missing one file looks almost exactly like a finished one.
+    """
+    if dry_run:
+        print("  DRY RUN, not waiting")
+        return
+    deadline = time.time() + wait_seconds
+    while True:
+        release = gh_json("release", "view", tag, "--repo", REPO,
+                          "--json", "assets,isDraft")
+        names = sorted(asset["name"] for asset in release.get("assets", []))
+        has_sbom_statement = any(n.endswith(".sbom.sigstore.json") for n in names)
+        if has_sbom_statement:
+            break
+        if time.time() > deadline:
+            raise SystemExit(
+                "sign_release: the statement about the signed bytes has not arrived after "
+                "%d seconds.\nThe draft holds: %s\nLook at the run of %s before publishing "
+                "anything." % (wait_seconds, ", ".join(names), ATTEST_WORKFLOW))
+        print("    waiting for %s ..." % ATTEST_WORKFLOW)
+        time.sleep(10)
+
+    release = gh_json("release", "view", tag, "--repo", REPO, "--json", "assets,isDraft")
+    names = sorted(asset["name"] for asset in release.get("assets", []))
+    missing = []
+    if sum(1 for n in names if n.endswith((".zip", ".tar.gz"))) != 8:
+        missing.append("eight archives")
+    for needed in ("SHA256SUMS.txt", ".spdx.json", ".sbom.sigstore.json",
+                   ".provenance.sigstore.json"):
+        if not any(n.endswith(needed) or n == needed for n in names):
+            missing.append(needed)
+    if missing:
+        raise SystemExit(
+            "sign_release: the draft is not complete - missing %s.\nIt holds: %s"
+            % (", ".join(missing), ", ".join(names)))
+    if not release.get("isDraft"):
+        raise SystemExit(
+            "sign_release: %s is no longer a draft. Nothing here publishes, so "
+            "somebody or something else did." % tag)
+    print("  the draft holds %d asset(s) and is still a draft" % len(names))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("tag", help="the release tag, for example v0.2.0")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="everything except signing, uploading and dispatching")
+    parser.add_argument("--wait", type=int, default=300,
+                        help="seconds to wait for the statement (default 300)")
+    args = parser.parse_args(argv)
+
+    if not os.path.isfile(PIN_FILE):
+        raise SystemExit("sign_release: run this from the root of the repository")
+    pin = pinned_digest()
+    work = os.path.join("dist", "signing", args.tag)
+
+    print("\n[1/7] fetching the build for %s" % args.tag)
+    fetch_build(args.tag, work)
+
+    print("\n[2/7] checking it before touching it")
+    verify_before_touching(work)
+
+    print("\n[3/7] the card")
+    thumbprint = signing_thumbprint(pin)
+    signtool = find_signtool()
+
+    print("\n[4/7] signing the Windows programs")
+    for name in windows_archives(work):
+        sign_archive(os.path.join(work, name), thumbprint, pin, signtool, args.dry_run)
+
+    print("\n[5/7] checksums over what will be published")
+    name_for_publication(work, args.tag)
+    digest = write_checksums(work)
+    print("  SHA256SUMS.txt: %s" % digest)
+
+    print("\n[6/7] uploading to the draft")
+    upload_to_draft(args.tag, work, args.dry_run)
+    ask_for_the_statement(args.tag, digest, args.dry_run)
+
+    print("\n[7/7] waiting for the statement and checking the draft")
+    confirm_draft(args.tag, args.wait, args.dry_run)
+
+    print("\nDone. %s is a complete DRAFT." % args.tag)
+    print("Read it, then publish it from the Releases page.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/attest-release.yml
+++ b/.github/workflows/attest-release.yml
@@ -1,0 +1,134 @@
+# The second half of a release, after a person has signed it.
+#
+# The build workflow cannot sign. The key lives on a cryptographic card in a USB
+# reader and cannot be exported, so .github/scripts/sign_release.py signs on the
+# maintainer's machine and then dispatches this. Here the signed files get the
+# statement that travels with them, and the release is still a draft when this
+# finishes.
+#
+# 🔴 It DOWNLOADS what the release holds rather than trusting the digest it was
+# handed. Everything attested here is then a statement about bytes this job is
+# holding, which is the whole difference between an attestation and a rumour.
+# The digest input is kept as a cross-check: if it disagrees with the file on the
+# release, something moved between signing and publishing and the run stops.
+#
+# What it does NOT do: build provenance. That belongs to the workflow that
+# actually built something, and it is made there, over the unsigned build.
+# Claiming here that this workflow produced files a person signed on their own
+# machine would be false in the one document nobody should have to doubt.
+name: Attest a signed release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The release tag, for example v0.2.0"
+        required: true
+      digest:
+        description: "sha256 of SHA256SUMS.txt, as sign_release.py printed it"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  attest:
+    name: attest the signed files
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      # Reading the draft's assets and uploading the bundle back to it.
+      contents: write
+      # id-token mints the short lived OIDC token that signs the attestation,
+      # attestations writes the result to this repository's store.
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: fetch what the maintainer signed
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+          CLAIMED: ${{ inputs.digest }}
+        run: |
+          set -euo pipefail
+          mkdir -p signed
+          cd signed
+          gh release download "$TAG" --pattern '*.zip' --pattern '*.tar.gz' \
+            --pattern '*.spdx.json' --pattern 'SHA256SUMS.txt'
+          actual="$(sha256sum SHA256SUMS.txt | cut -d' ' -f1)"
+          echo "the release carries: $actual"
+          if [ "$actual" != "$CLAIMED" ]; then
+            echo "::error::the checksums file on the release hashes to $actual, but this run"
+            echo "::error::was dispatched for $CLAIMED - something changed in between"
+            exit 1
+          fi
+          # And the checksums have to describe the files that came with them,
+          # because everything below is a statement about that list.
+          sha256sum -c SHA256SUMS.txt
+          sbom="$(ls -- *.spdx.json)"
+          echo "SBOM=signed/${sbom}" >> "$GITHUB_ENV"
+          echo "SUMS=signed/SHA256SUMS.txt" >> "$GITHUB_ENV"
+
+      # The bill of materials, bound to the files a person actually downloads.
+      # Before the signature existed this binding was made at build time. It is
+      # made here now, because the signature changes the bytes and a statement
+      # about the wrong bytes verifies against nothing.
+      - name: attest what is inside the signed files
+        id: attestation
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6  # v4.2.2
+        with:
+          subject-checksums: ${{ env.SUMS }}
+          sbom-path: ${{ env.SBOM }}
+
+      - name: the release notes promise a command, so check the command works
+        shell: bash
+        env:
+          BUNDLE: ${{ steps.attestation.outputs.bundle-path }}
+        # 🔴 The notes tell people to pass --predicate-type, because gh asks for
+        # build provenance unless told otherwise and this is not that. The URI in
+        # those notes is written by hand, so it is checked here against the
+        # statement that was actually made - the only moment where the real value
+        # exists. A wrong URI would make a correct release look broken, and the
+        # message a person gets is "no attestation found", which reads like a
+        # missing file rather than a wrong flag.
+        run: |
+          set -euo pipefail
+          promised="https://spdx.dev/Document"
+          actual="$(python3 - "$BUNDLE" <<'PY'
+          import base64, json, sys
+          bundle = json.load(open(sys.argv[1], encoding="utf-8"))
+          payload = bundle["dsseEnvelope"]["payload"]
+          statement = json.loads(base64.b64decode(payload))
+          print(statement["predicateType"])
+          PY
+          )"
+          echo "the statement carries: $actual"
+          if [ "$actual" != "$promised" ]; then
+            echo "::error::the release notes tell people to pass --predicate-type $promised"
+            echo "::error::and the statement that was just made is $actual."
+            echo "::error::Fix the notes in release.yml, because as written the command answers"
+            echo "::error::\"no attestation found\" and that reads like a broken release."
+            exit 1
+          fi
+
+      - name: publish the statement beside the files
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+          BUNDLE: ${{ steps.attestation.outputs.bundle-path }}
+        # 🔴 As an ASSET, not only in the attestation store. Scorecard's signed
+        # releases check reads assets by file extension and never opens that
+        # store, and a person whose network has no route to the API cannot use it
+        # either. "gh attestation verify <file> --bundle <this file>" answers
+        # offline, from a mirror, from anywhere.
+        run: |
+          set -euo pipefail
+          name="tfg_${TAG#v}.sbom.sigstore.json"
+          cp "$BUNDLE" "$name"
+          python3 -c "import json,sys; json.load(open(sys.argv[1])); print('the bundle parses as JSON')" "$name"
+          gh release upload "$TAG" "$name" --clobber
+          echo "attached $name to $TAG, which is still a draft"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,56 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "the code says $version"
 
+      - name: the tree was green on this exact commit
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # This workflow builds and publishes. It does run the suite above, but
+        # the suite is not the whole of CI - the linters, the scanners, the
+        # coverage gate and the reference tools all live in the CI workflow and
+        # none of them runs here. Without this, the only thing standing between
+        # a red tree and a published release is somebody remembering.
+        #
+        # 🔴 Asked BY NAME rather than as "were all the checks green". A query
+        # for every check answers about whatever happened to report, so a
+        # workflow that never ran reads exactly like one that passed.
+        run: |
+          set -euo pipefail
+          verdict="$(gh run list --workflow=CI --commit="${GITHUB_SHA}" \
+            --limit 1 --json conclusion --jq '.[0].conclusion // "never ran"')"
+          echo "CI on ${GITHUB_SHA}: ${verdict}"
+          if [ "$verdict" != "success" ]; then
+            echo "The CI workflow on this commit says: ${verdict}."
+            echo "A release is built from a commit CI has passed, so push the commit,"
+            echo "wait for CI, and tag it only then."
+            exit 1
+          fi
+
+      - name: the changelog is closed for this version
+        if: startsWith(github.ref, 'refs/tags/')
+        # A release page points at the changelog, and a changelog whose section
+        # for this version does not exist points back at nothing. The other
+        # half matters more: entries left under Unreleased are changes that went
+        # out without being described, and nobody notices until the next release
+        # inherits them.
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          if ! grep -q "^## \[${version}\]" CHANGELOG.md; then
+            echo "CHANGELOG.md has no section for ${version}."
+            echo "Move what is under [Unreleased] into a dated section for this version first."
+            exit 1
+          fi
+          # Everything between [Unreleased] and the next version heading. A
+          # heading of its own with nothing under it is what "closed" means.
+          left="$(awk '/^## \[Unreleased\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md | grep -c '[^[:space:]]' || true)"
+          if [ "$left" != "0" ]; then
+            echo "CHANGELOG.md still has ${left} line(s) under [Unreleased]."
+            echo "Those are changes that would go out undescribed. Move them into ${version}."
+            exit 1
+          fi
+          echo "changelog is closed for ${version}"
+
       - name: the tag says the same as the code
         if: startsWith(github.ref, 'refs/tags/')
         # The version lives in internal/version and only the owner raises it -
@@ -305,15 +355,18 @@ jobs:
             -o "incoming/tfg_${version}.spdx.json"
           echo "SBOM=incoming/tfg_${version}.spdx.json" >> "$GITHUB_ENV"
 
-      - name: one list of what is being published
+      - name: one list of what this build produced
+        # build.sha256 rather than SHA256SUMS.txt, and the difference is the
+        # whole point of this phase. These are the bytes the RUNNER made. Three
+        # of the archives get a signature on the maintainer's machine, which
+        # changes them, so the list a user checks is written there, over what
+        # they will actually download. This one exists so the statement below
+        # names exactly what was built.
         run: |
           set -euo pipefail
           cd incoming
-          # Bare names rather than ./name. Somebody checking one download runs
-          # sha256sum -c beside the file they just fetched, and a leading ./ is
-          # one more thing between them and an answer.
-          sha256sum -- * > SHA256SUMS.txt
-          cat SHA256SUMS.txt
+          sha256sum -- * > build.sha256
+          cat build.sha256
 
       # WHO built it, and FROM WHAT. This says the files came out of this
       # repository, from this commit, through this workflow, on a GitHub hosted
@@ -340,33 +393,16 @@ jobs:
         id: provenance
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
         with:
-          subject-checksums: incoming/SHA256SUMS.txt
+          subject-checksums: incoming/build.sha256
 
-      # WHAT IS INSIDE. A separate statement from a separate action on purpose:
-      # the one above builds its predicate from the workflow's own context and
-      # there is nothing to hand it, while this one carries a document we
-      # generated. Two questions, two answers.
-      - name: attest what is inside it
-        id: sbom
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6  # v4.2.2
-        with:
-          subject-checksums: incoming/SHA256SUMS.txt
-          sbom-path: ${{ env.SBOM }}
-
-      - name: publish the statements beside the files
-        # As RELEASE ASSETS, not only in the attestation store. Scorecard reads
-        # assets by file extension and never opens that store, and a person
-        # behind a proxy that blocks the API cannot use it either. With the
-        # bundle beside the archive, "gh attestation verify <file> --bundle
-        # <bundle>" answers offline, from a mirror, from anywhere.
-        run: |
-          set -euo pipefail
-          version="${{ needs.check.outputs.version }}"
-          cp "${{ steps.provenance.outputs.bundle-path }}" \
-             "incoming/tfg_${version}.provenance.sigstore.json"
-          cp "${{ steps.sbom.outputs.bundle-path }}" \
-             "incoming/tfg_${version}.sbom.sigstore.json"
-          ls -l incoming
+      - name: keep the statement with the build
+        # The bundle travels with the artefact rather than to the release page.
+        # Five of the eight archives are the finished article - nothing signs a
+        # Linux or a macOS build here - so for those this statement describes
+        # the bytes a user will hold. For the three Windows archives it
+        # describes what the runner made before a person signed it, which is
+        # true and is not what anybody downloads.
+        run: cp "${{ steps.provenance.outputs.bundle-path }}" incoming/build.provenance.sigstore.json
 
       - name: notes
         run: |
@@ -382,31 +418,44 @@ jobs:
             echo "Match the file to your system and architecture. Check what you downloaded against"
             echo "\`SHA256SUMS.txt\`."
             echo
-            echo "## These binaries are not signed"
+            echo "## Signing"
             echo
-            echo "Signing is not set up yet, so your system will say so."
+            echo "**Windows binaries are signed.** The signature is on the program inside the zip,"
+            echo "carries a timestamp, and names \`Open Source Developer Dominik Babiarz\`, issued by"
+            echo "Certum. Windows checks it when you run the program."
             echo
-            echo "- **Windows** shows a SmartScreen warning. More info, then Run anyway."
+            echo "**macOS and Linux binaries are not signed yet.**"
+            echo
             echo "- **macOS** refuses to open it on the first try. Open it from the right click menu,"
             echo "  or allow it in System Settings under Privacy and Security."
             echo "- **Linux** says nothing, but you may need \`chmod +x\`."
             echo
-            echo "If that is not a trade you want to make, build from source - it takes one command"
-            echo "and the readme has it."
+            echo "## What you can check without trusting this page"
             echo
-            echo "## What you can check"
+            echo "What is inside any of these files, signed when the release was made:"
             echo
-            echo "Every file here carries two statements made when it was built: where it came from,"
-            echo "and what is inside it. Both are signed by the build itself, and neither needs a"
-            echo "certificate from us."
+            echo "\`\`\`"
+            echo "gh attestation verify <the file you downloaded> -R ${GITHUB_REPOSITORY} \\"
+            echo "   --predicate-type https://spdx.dev/Document"
+            echo "\`\`\`"
+            echo
+            echo "The predicate type has to be given. \`gh\` asks for build provenance unless told"
+            echo "otherwise, and that is a different statement - see below."
+            echo
+            echo "Where a **macOS or Linux** archive came from. These are exactly the bytes the"
+            echo "build produced, so the build's own statement still describes them:"
             echo
             echo "\`\`\`"
             echo "gh attestation verify <the file you downloaded> -R ${GITHUB_REPOSITORY}"
             echo "\`\`\`"
             echo
+            echo "That one does not answer for a **Windows** archive, and deliberately: a person"
+            echo "signed those on their own machine after the build, so the bytes are no longer the"
+            echo "bytes the runner made. Their signature is the Authenticode one above."
+            echo
             echo "The \`.spdx.json\` file lists every library and every font compiled into these"
             echo "binaries, with its licence. The \`.sigstore.json\` files are the statements"
-            echo "themselves, so the command above also works offline with \`--bundle\`."
+            echo "themselves, so both commands also work offline with \`--bundle\`."
             echo
             echo "## Everything that changed"
             echo
@@ -414,18 +463,45 @@ jobs:
           } > notes.md
           cat notes.md
 
-      - name: create the draft release
+      - name: open the draft, with nothing in it yet
         env:
           GH_TOKEN: ${{ github.token }}
-        # A draft, so the tag starts the release and the owner finishes it. It
-        # is also the last chance to read the notes before anybody downloads
-        # anything. A tag whose name carries a hyphen - v0.2.0-rc1 - is marked
-        # a prerelease as well.
+        # 🔴 No assets. This phase does not publish archives and does not write
+        # the checksums a user reads, because these are not the bytes a user
+        # gets: three of them are signed afterwards on the machine that holds
+        # the card. An unsigned executable on a public release page - even for
+        # a quarter of an hour - is an executable somebody downloads.
+        #
+        # A draft, so the tag starts the release and a person finishes it. A tag
+        # whose name carries a hyphen - v0.2.0-rc1 - is marked a prerelease.
         run: |
           set -euo pipefail
           flags=(--draft --title "${GITHUB_REF_NAME}" --notes-file notes.md)
           case "${GITHUB_REF_NAME}" in
             *-*) flags+=(--prerelease) ;;
           esac
-          gh release create "${GITHUB_REF_NAME}" "${flags[@]}" incoming/*
-          echo "drafted ${GITHUB_REF_NAME} - publish it from the Releases page"
+          gh release create "${GITHUB_REF_NAME}" "${flags[@]}"
+          echo "drafted ${GITHUB_REF_NAME}, empty on purpose"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        # The build, handed to the machine with the card. This is the seam
+        # between where builds belong and where signatures belong, and the name
+        # is what the signing script asks for.
+        with:
+          name: unsigned-build-${{ github.ref_name }}
+          path: incoming/*
+          if-no-files-found: error
+
+      - name: what happens next
+        run: |
+          set -euo pipefail
+          echo "Built, attested, and opened as an EMPTY DRAFT."
+          echo
+          echo "Nothing is published yet. On the machine with the card:"
+          echo
+          echo "    python .github/scripts/sign_release.py ${GITHUB_REF_NAME}"
+          echo
+          echo "That verifies this build's provenance before touching it, signs the three"
+          echo "Windows binaries with the card, writes SHA256SUMS.txt over what it made,"
+          echo "uploads everything to the draft and asks attest-release.yml for the statement"
+          echo "about the signed bytes. Then read the draft and publish it."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,19 @@ because it turns other people's test suites red.
 
 ### Added
 
+- **Windows binaries are signed.** The signature sits on the program inside the
+  zip, carries an RFC 3161 timestamp, and names an Open Source Developer
+  certificate issued by Certum. Windows checks it when you run the program, so
+  the SmartScreen warning that used to greet every download is gone.
+
+  macOS and Linux binaries are not signed yet and the release notes say so.
+
+  A release is now made in two halves. A tag builds everything and opens an
+  empty draft. A person with the signing card runs one script, which checks the
+  build's own provenance before touching it, signs, writes the checksums over
+  what it made, and asks a workflow for the statement about the signed bytes.
+  Nothing is published until somebody reads the draft and presses the button.
+
 - Every file in a release now carries two statements made while it was built:
   where it came from, and what is inside it. Both are signed by the build with
   a short lived identity and written to a public log, so anybody can check a

--- a/internal/guard/attestation_test.go
+++ b/internal/guard/attestation_test.go
@@ -68,65 +68,71 @@ func TestTheReleaseAsksForWhatAnAttestationNeeds(t *testing.T) {
 	}
 }
 
-// Two statements, two actions, and each over the files the release actually
-// publishes rather than over a glob that might match something else.
-func TestTheReleaseAttestsEveryFileItPublishes(t *testing.T) {
+// The build states what IT made, over a list of exactly those files.
+//
+// It says nothing about what is inside them any more, and that moved rather
+// than disappeared: three of these archives get a signature afterwards, which
+// changes their bytes, so the statement about what a person downloads is made
+// by attest-release.yml over the signed files. A statement about the wrong
+// bytes verifies against nothing.
+func TestTheReleaseAttestsWhatItBuilt(t *testing.T) {
 	job := releasePublishJob(t)
 
-	wanted := map[string]bool{
-		"actions/attest-build-provenance": false,
-		"actions/attest":                  false,
-	}
+	attested := false
 	for _, step := range job.Steps {
 		action, _, _ := strings.Cut(step.Uses, "@")
-		if _, want := wanted[action]; !want {
+		if action != "actions/attest-build-provenance" {
 			continue
 		}
-		wanted[action] = true
-		// The list of checksums is the list the release publishes, so the
-		// statement covers exactly what is on the page, under the names people
-		// download. A glob would cover whatever happened to be in the
-		// directory.
-		if got, _ := step.With["subject-checksums"].(string); got != "incoming/SHA256SUMS.txt" {
-			t.Errorf("%s attests %q rather than the checksums of what is published", action, got)
+		attested = true
+		// A list rather than a glob: the statement then covers exactly what was
+		// built, under the names it was built under.
+		if got, _ := step.With["subject-checksums"].(string); got != "incoming/build.sha256" {
+			t.Errorf("the build attests %q rather than the list of what it produced", got)
 		}
 	}
-	for action, found := range wanted {
-		if !found {
-			t.Errorf("the release never runs %s, so it publishes files nobody can check", action)
-		}
+	if !attested {
+		t.Error("the build makes no statement about what it produced, " +
+			"so the signing step has nothing to check before it signs")
 	}
 }
 
-// The document has to be generated and the statements have to end up beside the
-// downloads. An attestation only in the store is one a person behind a proxy
-// cannot reach, and Scorecard reads assets by extension and never opens it.
-func TestTheReleasePublishesItsDocumentAndItsStatements(t *testing.T) {
+// The document is generated where the versions can be read, and it travels with
+// the build to the machine that signs. The statements end up beside the
+// downloads rather than only in the attestation store: a person behind a proxy
+// cannot reach that store, and Scorecard reads assets by extension and never
+// opens it.
+func TestTheReleaseMakesItsDocumentAndHandsItOver(t *testing.T) {
 	job := releasePublishJob(t)
 
 	var script strings.Builder
-	sbomAttested := false
 	for _, step := range job.Steps {
 		script.WriteString(step.Run)
 		script.WriteString("\n")
-		if _, ok := step.With["sbom-path"]; ok {
-			sbomAttested = true
-		}
 	}
 	all := script.String()
 
 	for what, want := range map[string]string{
-		"the bill of materials is generated":             "go run ./internal/legal/cmd/sbom",
-		"it is written where the release publishes from": "-o \"incoming/tfg_${version}.spdx.json\"",
-		"the provenance bundle becomes an asset":         "provenance.sigstore.json",
-		"the sbom bundle becomes an asset":               "sbom.sigstore.json",
+		"the bill of materials is generated":           "go run ./internal/legal/cmd/sbom",
+		"it is written where the build is handed over": "-o \"incoming/tfg_${version}.spdx.json\"",
+		"the statement travels with the build":         "build.provenance.sigstore.json",
 	} {
 		if !strings.Contains(all, want) {
 			t.Errorf("%s: the publish job never runs %q", what, want)
 		}
 	}
-	if !sbomAttested {
-		t.Error("no step attests the bill of materials, so the document travels unsigned")
+
+	// And the ritual that follows publishes both statements as assets. One is
+	// renamed by the signing script, the other is uploaded by the workflow that
+	// makes it.
+	signing := signingScript(t)
+	if !strings.Contains(signing, "provenance.sigstore.json") {
+		t.Error("the signing script never publishes the build's statement, " +
+			"so verifying a Linux or macOS archive offline is impossible")
+	}
+	attest := workflowText(t, "attest-release.yml")
+	if !strings.Contains(attest, "sbom.sigstore.json") {
+		t.Error("nothing publishes the statement about what is inside the signed files")
 	}
 }
 

--- a/internal/guard/signing_test.go
+++ b/internal/guard/signing_test.go
@@ -1,0 +1,173 @@
+package guard
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/donislawdev/TestingFilesGenerator/internal/legal"
+)
+
+// Signing splits a release in two, and the split is the point.
+//
+// The key is on a card in a USB reader and cannot be exported. No GitHub hosted
+// runner can reach it, and a self hosted runner in a public repository is a
+// machine strangers can aim a pull request at. So the build happens where
+// builds belong, the signature happens where the card is, and what travels
+// between them is an artefact plus a statement about it.
+//
+// These guards are over the seam. Every one of them is about a failure that is
+// quiet: an unsigned file published for a quarter of an hour, a build signed
+// without being checked, a second certificate signing just as willingly, a
+// release page that looks finished and is missing a file.
+
+func workflowText(t *testing.T, name string) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(repoRoot(t), ".github", "workflows", name))
+	if err != nil {
+		t.Skipf("no %s here: %v", name, err)
+	}
+	return string(body)
+}
+
+func signingScript(t *testing.T) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(repoRoot(t), ".github", "scripts", "sign_release.py"))
+	if err != nil {
+		t.Skipf("no signing script here: %v", err)
+	}
+	return string(body)
+}
+
+// The build workflow hands the build over. It does not publish it.
+func TestTheReleaseHandsTheBuildOverInsteadOfPublishingIt(t *testing.T) {
+	release := workflowText(t, "release.yml")
+
+	// An unsigned executable on a release page - even for a quarter of an hour,
+	// even on a draft whose asset URLs exist - is an executable somebody
+	// downloads. Three of these archives are signed afterwards, so none of them
+	// goes up here.
+	if regexp.MustCompile(`gh release create[^\n]*incoming`).MatchString(release) {
+		t.Error("the release workflow uploads archives when it opens the draft, " +
+			"and three of them have not been signed yet")
+	}
+	for _, want := range []string{
+		"name: unsigned-build-${{ github.ref_name }}",
+		"sign_release.py",
+	} {
+		if !strings.Contains(release, want) {
+			t.Errorf("the release workflow never mentions %q, so the build reaches nobody", want)
+		}
+	}
+	// The checksums a person reads are written where the final bytes are made.
+	// This phase writes its own list, for its own statement, under its own name.
+	if !strings.Contains(release, "sha256sum -- * > build.sha256") {
+		t.Error("the build no longer lists what it produced, so the statement below it names nothing")
+	}
+	if strings.Contains(release, "sha256sum -- * > SHA256SUMS.txt") {
+		t.Error("the build writes the checksums a user reads, and three of the files still change afterwards")
+	}
+}
+
+// Two questions asked before anything is built, both of which used to be
+// answered by somebody remembering.
+func TestTheReleaseChecksTheTreeAndTheChangelogFirst(t *testing.T) {
+	release := workflowText(t, "release.yml")
+
+	// By name. A query for every check answers about whatever happened to
+	// report, so a workflow that never ran reads exactly like one that passed.
+	if !strings.Contains(release, "gh run list --workflow=CI --commit=") {
+		t.Error("nothing asks whether CI passed on the commit being released.\n" +
+			"This workflow builds and publishes and runs none of the linters, scanners or gates.")
+	}
+	if !strings.Contains(release, "grep -q \"^## \\[${version}\\]\" CHANGELOG.md") {
+		t.Error("nothing checks that the changelog has a section for the version being released")
+	}
+	if !strings.Contains(release, "[Unreleased]") {
+		t.Error("nothing checks that entries were moved out of Unreleased, so changes could ship undescribed")
+	}
+}
+
+// What the script refuses is worth more than what it does.
+func TestTheSigningScriptRefusesBeforeItSigns(t *testing.T) {
+	script := signingScript(t)
+
+	for what, want := range map[string]string{
+		"it verifies the build before touching it":                  "gh\", \"attestation\", \"verify\"",
+		"it timestamps, or the signature dies with the certificate": "/tr",
+		"it reads the certificate back out of the signed file":      "certificate_of(program)",
+		"it selects the certificate by OID rather than by a name":   "1.3.6.1.5.5.7.3.3",
+		"it reads the pin from one place":                           "codesign.go",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("%s: the script does not contain %q", what, want)
+		}
+	}
+
+	// Nothing here publishes. The release stays a draft until a person reads it.
+	for _, forbidden := range []string{"--draft=false", "release edit", "gh release publish"} {
+		if strings.Contains(script, forbidden) {
+			t.Errorf("the signing script contains %q, and nothing in this ritual may publish", forbidden)
+		}
+	}
+}
+
+// The workflow that speaks about signed bytes must not claim to have built them.
+func TestTheAttestationWorkflowDoesNotClaimToHaveBuiltAnything(t *testing.T) {
+	attest := workflowText(t, "attest-release.yml")
+
+	if strings.Contains(attest, "attest-build-provenance") {
+		t.Error("the attestation workflow claims build provenance for files a person signed " +
+			"on their own machine, which is false in the one document nobody should have to doubt")
+	}
+	for what, want := range map[string]string{
+		"it downloads what the release holds":                       "gh release download",
+		"it cross-checks the digest it was given":                   "CLAIMED",
+		"it checks the checksums describe the files they came with": "sha256sum -c SHA256SUMS.txt",
+		"it attests the document against those bytes":               "sbom-path",
+		"it publishes the statement as an asset":                    "gh release upload",
+	} {
+		if !strings.Contains(attest, want) {
+			t.Errorf("%s: the workflow does not contain %q", what, want)
+		}
+	}
+
+	// The notes tell people to pass a predicate type, because gh asks for build
+	// provenance unless told otherwise. The URI is written by hand in one place
+	// and checked against a real statement in the other, at the only moment the
+	// real value exists.
+	release := workflowText(t, "release.yml")
+	promised := regexp.MustCompile(`--predicate-type (\S+)`).FindStringSubmatch(release)
+	if promised == nil {
+		t.Fatal("the release notes no longer tell anybody which predicate type to ask for")
+	}
+	if !strings.Contains(attest, promised[1]) {
+		t.Errorf("the notes promise --predicate-type %s and the attestation workflow never checks it.\n"+
+			"A wrong URI answers \"no attestation found\", which reads like a broken release.",
+			promised[1])
+	}
+}
+
+// The pin is a digest of bytes, not a name somebody can rename.
+func TestThePinnedCertificateIsADigestWithADate(t *testing.T) {
+	if !regexp.MustCompile(`^[0-9a-f]{64}$`).MatchString(legal.CodeSigningSHA256) {
+		t.Errorf("the pinned certificate is %q, which is not a sha256", legal.CodeSigningSHA256)
+	}
+	expires, err := time.Parse("2006-01-02", legal.CodeSigningExpires)
+	if err != nil {
+		t.Fatalf("the certificate expiry %q is not a date: %v", legal.CodeSigningExpires, err)
+	}
+	// Not an assertion about today - a certificate expiring is a fact of life
+	// and a red suite on the day it happens helps nobody. The script refuses to
+	// sign with an expired certificate, which is where the refusal belongs.
+	t.Logf("the pinned certificate expires %s", expires.Format("2006-01-02"))
+
+	// And the script has to read this file rather than carry its own copy.
+	if !strings.Contains(signingScript(t), "CodeSigningSHA256") {
+		t.Error("the signing script does not read the pin from internal/legal, " +
+			"so there are two written copies of one digest")
+	}
+}

--- a/internal/legal/codesign.go
+++ b/internal/legal/codesign.go
@@ -1,0 +1,40 @@
+// The certificate this project signs Windows binaries with, pinned by the
+// digest of its own bytes.
+//
+// The key is on a cryptographic card in a USB reader and cannot be exported.
+// That is the whole value of it and the reason signing is a step a person runs
+// rather than a job on a runner: no GitHub hosted runner can reach the card, a
+// self hosted one could, and this is a public repository where a self hosted
+// runner is a machine strangers can aim a pull request at.
+//
+// What is written here is the digest and nothing else. The certificate's own
+// subject carries the owner's town and region - it is embedded in every file it
+// signs and becomes public the first time a signed release goes out, which is a
+// thing to say out loud once rather than to spread through a repository.
+
+package legal
+
+// CodeSigningSHA256 is the SHA-256 of the signing certificate's DER bytes.
+//
+// Read from the card on 2026-08-28: "Open Source Developer Dominik Babiarz",
+// issued by Certum Code Signing 2021 CA, valid until 2027-08-19.
+//
+// Why this digest rather than the SHA-1 thumbprint Windows selects by: the
+// thumbprint is what signtool takes as a selector and SHA-1 is not a digest
+// worth pinning anything to. The script resolves one to the other at signing
+// time, so the two cannot drift apart in a configuration file.
+//
+// A renewal is a DIFFERENT certificate and this line has to move with it.
+// The signing script refuses when the certificate that actually signed a file
+// does not hash to this, which is exactly the accident worth catching: a second
+// code signing certificate on the same machine signs just as willingly, and the
+// release page looks identical either way.
+const CodeSigningSHA256 = "47b79ad3cfa53ef846cad03a59148f8c981d0b1196891e48b8c8d7982b10c148"
+
+// CodeSigningExpires is when that certificate stops being able to sign.
+//
+// Written down so a check can warn before it happens rather than after. The
+// signature outlives it - every signature this project makes carries an RFC
+// 3161 timestamp, and without one a signature dies with its certificate - but
+// nothing new can be signed past this date.
+const CodeSigningExpires = "2027-08-19"


### PR DESCRIPTION
⚠️ **Merge this from the browser** - it touches `.github/workflows/**` and the `gh` token has no `workflow` scope.

## What changes

Windows binaries get a signature. The key is on a card that cannot be exported, so no runner can reach it, and a release becomes two halves with a seam between them.

**The build stops publishing.** It opens an **empty draft** and hands the build over as an artefact, because three of the eight archives change bytes when they are signed - and an unsigned executable on a release page, even for a quarter of an hour, is one somebody downloads.

**`.github/scripts/sign_release.py`** runs where the card is. It verifies the build's own provenance **before touching it**, signs with an RFC 3161 timestamp, reads the certificate back out of each signed file and refuses unless it hashes to the pin, repacks, writes `SHA256SUMS.txt` over what it made, uploads to the draft, asks for the statement and waits until the draft is complete. Nothing in it publishes.

**`attest-release.yml`** speaks about the signed bytes: downloads what the release holds rather than trusting the digest it was handed, attests the bill of materials against those bytes, and deliberately does **not** attest provenance - a person signed those files.

## Two checks that used to be somebody remembering

- **CI green on this exact commit, asked by name.** This workflow builds and publishes and runs none of the linters, scanners or gates. A query for every check reads a workflow that never ran exactly like one that passed.
- **The changelog is closed**: a section for this version exists and nothing is left under `[Unreleased]`.

## Measured, and it would have cost an evening

Selecting the signing certificate by the display name `Code Signing` finds **nothing** on a Polish Windows, which calls it `Podpisywanie kodu`. The script would have reported a missing card while the card was plugged in and working, and the person holding it would have started debugging the reader. It selects by **OID**, and a mutation puts the old bug back.

Also measured: `signtool` is present (SDK 10.0.28000), three of eight archives are signable, and the certificate is valid until 2027-08-19.

## One thing deliberately not guessed

The predicate type the notes tell people to pass with `gh attestation verify` is not in the action's source. The notes state it, and the workflow that makes the statement **checks that promise against the real thing** and stops the release when it disagrees - because a wrong URI answers "no attestation found", which reads like a broken release rather than a wrong flag.

## Guards

Seven, seven mutations, all caught. Two older guards were rewritten rather than deleted: the behaviour they watched **moved** to the second half of the ritual.

## Still to come

Phase D - a read-only workflow on "release published" that checks the page a user actually sees: complete assets, checksums, the README commands run literally, the signature and its timestamp, the certificate digest, and that `latest` points at it.

## Checked

`go test ./...` exit 0, `python tools/preflight.py --quick` 11 of 11, every `run:` step of both workflows parsed by bash, and the script's refusals exercised.