### PR TITLE
The macOS half carries a ticket a bare binary could not hold

### DIFF
--- a/.github/scripts/make_app_bundle.sh
+++ b/.github/scripts/make_app_bundle.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Wrap a macOS binary in a .app bundle, because that is the only shape that can
+# carry a notarisation ticket.
+#
+# Measured on 2026-08-28, on a real Developer ID certificate and two real
+# notarisations - see docs, section 15 of the provenance plan:
+#
+#   * a bare Mach-O binary cannot be stapled at all. stapler exits 66 and says
+#     it "is incapable of working with Document files", and Gatekeeper then
+#     rejects the binary (spctl exit 3) even when it is signed AND notarised;
+#   * a .dmg staples fine and does not help: the binary INSIDE a stapled dmg is
+#     still rejected, because the ticket describes the container;
+#   * a .app staples (exit 0) and is accepted (spctl exit 0), and the ticket
+#     survives being packed into tar.gz and unpacked again.
+#
+# So the bundle is not decoration. It is the thing the ticket attaches to.
+#
+# A symlink goes next to the bundle so that a person still types ./tfg. The
+# binary must NOT be lifted out of the bundle - a copy of it on its own is
+# rejected with "invalid resource directory", because the signature covers the
+# bundle, not the file.
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "usage: make_app_bundle.sh <workdir> <binary> <bundle-id> <version>" >&2
+  exit 2
+fi
+
+work="$1"
+binary="$2"
+bundle_id="$3"
+version="$4"
+
+if [ ! -f "${work}/${binary}" ]; then
+  echo "make_app_bundle: ${work}/${binary} is not there, nothing to wrap" >&2
+  exit 1
+fi
+
+app="${work}/${binary}.app"
+mkdir -p "${app}/Contents/MacOS"
+mv "${work}/${binary}" "${app}/Contents/MacOS/${binary}"
+chmod +x "${app}/Contents/MacOS/${binary}"
+
+# LSMinimumSystemVersion is 11.0 because this project builds darwin/arm64 only
+# and Apple silicon starts there. NSHighResolutionCapable keeps the window from
+# being drawn blurry on a Retina display, and costs the command line nothing.
+cat > "${app}/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>${binary}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${bundle_id}</string>
+	<key>CFBundleName</key>
+	<string>${binary}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${version}</string>
+	<key>CFBundleVersion</key>
+	<string>${version}</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>11.0</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+</dict>
+</plist>
+PLIST
+
+# Relative, so it still points at the binary after the archive is unpacked
+# anywhere. Measured: the symlink survives tar.gz and running through it works.
+ln -s "${binary}.app/Contents/MacOS/${binary}" "${work}/${binary}"
+
+# On a filesystem that cannot make symlinks, ln quietly makes a COPY instead,
+# and a copy is far worse than nothing here: a binary sitting outside the bundle
+# is rejected by Gatekeeper with "invalid resource directory", because the
+# signature covers the bundle rather than the file. The archive would then carry
+# something that looks like the program and refuses to run. Measured 2026-08-28,
+# and measured by accident - a build on Windows produced exactly this.
+if [ ! -L "${work}/${binary}" ]; then
+  echo "make_app_bundle: ${binary} beside the bundle is a copy, not a symlink." >&2
+  echo "A copy of the binary outside the bundle is rejected by Gatekeeper." >&2
+  exit 1
+fi
+
+echo "wrapped ${binary} in ${binary}.app (${bundle_id}, ${version})"

--- a/.github/scripts/sign_macos.sh
+++ b/.github/scripts/sign_macos.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Sign, notarise and staple the macOS archives of a release. Runs ON THE MAC.
+#
+#   sign_macos.sh <directory> <certificate-sha256> <notarytool-profile>
+#
+# Why this is a separate script on a separate machine
+# ---------------------------------------------------
+# The Developer ID key lives in a keychain on the owner's Mac and Apple's notary
+# service will only talk to credentials stored there. The Windows card and this
+# key are on two different machines, so the release is signed in two places and
+# the checksums are written once, at the end, over everything.
+#
+# What it refuses, and why each refusal is there
+# ----------------------------------------------
+# Every one of these was measured on 2026-08-28, on real hardware, and several
+# of them are refusals precisely because the failure is SILENT otherwise:
+#
+#  * a locked keychain. codesign then exits 1 with errSecInternalComponent and
+#    leaves the file UNSIGNED, while the command looks like it did something.
+#    An ssh session is its own security session - launchctl managername says
+#    Background, not Aqua - so unlocking the keychain in the Mac's own Terminal
+#    does NOT carry over here;
+#  * a missing notarytool profile. Note that a LOCKED keychain reports the same
+#    error as a missing profile, so this script separates the two rather than
+#    blaming the owner for work they already did;
+#  * a certificate that is not the pinned one. A second Developer ID on the same
+#    machine signs just as willingly and the release looks identical;
+#  * notarisation that came back anything but Accepted;
+#  * a staple that did not take, or a bundle Gatekeeper still rejects. Without
+#    this last one the script would happily hand back an archive that fails on
+#    the first machine that downloads it.
+set -uo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: sign_macos.sh <directory> <certificate-sha256> <profile>" >&2
+  exit 2
+fi
+
+DIR="$1"
+PIN="$(echo "$2" | tr '[:lower:]' '[:upper:]')"
+PROFILE="$3"
+
+say() { echo "  $*"; }
+die() { echo "sign_macos: $*" >&2; exit 1; }
+
+# --------------------------------------------------------------------------- #
+# the keychain
+# --------------------------------------------------------------------------- #
+# Asked for on the terminal rather than taken as an argument or an environment
+# variable. A password in argv is visible in ps to every process on the machine.
+# This asks every time and does NOT claim to know whether it needed to, because
+# measured on 2026-08-28 it cannot know: over ssh, show-keychain-info answers
+# "User interaction is not allowed" (exit 36) even when the keychain is unlocked
+# and signing is about to work. An earlier version of this used that as a test
+# and so printed "the keychain is locked" at a moment when it was not - a
+# sentence that reads like a diagnosis and is really just a blind spot.
+#
+# Asking unconditionally is cheap: unlocking an already unlocked keychain
+# succeeds and changes nothing. The real proof that the key is reachable is
+# codesign itself, further down, which refuses loudly rather than silently.
+unlock_keychain() {
+  echo
+  echo "  An ssh session is its own security session and cannot see whether the"
+  echo "  keychain is unlocked, so it asks. If it is already unlocked, press"
+  echo "  Enter. Otherwise this is your Mac password."
+  echo
+  if ! security unlock-keychain "$HOME/Library/Keychains/login.keychain-db"; then
+    die "the keychain would not unlock, so nothing has been signed.
+Run this by hand on the Mac and try again:
+  security unlock-keychain ~/Library/Keychains/login.keychain-db"
+  fi
+  say "keychain reachable"
+}
+
+# --------------------------------------------------------------------------- #
+# the credentials, told apart from a locked keychain
+# --------------------------------------------------------------------------- #
+check_profile() {
+  local out rc
+  out="$(xcrun notarytool history --keychain-profile "$PROFILE" 2>&1)"
+  rc=$?
+  if [ $rc -eq 0 ]; then
+    say "notarytool profile '$PROFILE' answers"
+    return 0
+  fi
+  case "$out" in
+    *keychainLocked*)
+      die "the keychain locked itself again between two steps. Nothing signed." ;;
+    *"No Keychain password item"*)
+      die "there is no notarytool profile called '$PROFILE' on this Mac.
+Create it once, in the Mac's own Terminal rather than over ssh:
+
+  xcrun notarytool store-credentials \"$PROFILE\" --apple-id <your-apple-id> --team-id <your-team-id>
+
+It asks for an APP-SPECIFIC password from appleid.apple.com, not the password
+to the Apple account itself." ;;
+  esac
+  die "notarytool would not answer: $out"
+}
+
+# --------------------------------------------------------------------------- #
+# the certificate, chosen by its own bytes
+# --------------------------------------------------------------------------- #
+# codesign selects by SHA-1 and SHA-1 is not worth pinning anything to, so the
+# pin is a SHA-256 and the selector is derived from it here. That also settles
+# the ambiguity of the name: the same certificate is installed in both the login
+# and the system keychain, so "Developer ID Application" names two entries.
+find_identity() {
+  local sha1
+  sha1="$(security find-certificate -a -c "Developer ID Application" -Z 2>/dev/null |
+    awk -v pin="$PIN" '
+      /^SHA-256 hash:/ { s256 = $3 }
+      /^SHA-1 hash:/   { if (s256 == pin) { print $3; exit } }')"
+  [ -n "$sha1" ] ||
+    die "no Developer ID certificate on this Mac hashes to the pin $PIN.
+A renewal is a DIFFERENT certificate and internal/legal has to move with it."
+  security find-identity -v -p codesigning 2>/dev/null | grep -qi "$sha1" ||
+    die "the pinned certificate is installed but has no private key here, so it cannot sign"
+  echo "$sha1"
+}
+
+# The certificate that ACTUALLY signed a bundle, read back out of it.
+certificate_of() {
+  local bundle="$1" tmp
+  tmp="$(mktemp -d)"
+  ( cd "$tmp" && codesign -d --extract-certificates=cert "$bundle" >/dev/null 2>&1 )
+  if [ ! -f "$tmp/cert0" ]; then
+    rm -rf "$tmp"
+    echo "none"
+    return
+  fi
+  shasum -a 256 "$tmp/cert0" | awk '{print toupper($1)}'
+  rm -rf "$tmp"
+}
+
+# --------------------------------------------------------------------------- #
+# one archive, all the way through
+# --------------------------------------------------------------------------- #
+sign_archive() {
+  local archive="$1" identity="$2"
+  local name work app
+  name="$(basename "$archive")"
+  work="${archive}.unpacked"
+  rm -rf "$work"
+  mkdir -p "$work"
+  tar -xzf "$archive" -C "$work" || die "$name did not unpack"
+
+  app="$(find "$work" -maxdepth 1 -name '*.app' -type d | head -1)"
+  [ -n "$app" ] ||
+    die "$name holds no .app bundle. The release workflow is supposed to build
+one, because a bare binary cannot carry a notarisation ticket at all."
+
+  say "$name"
+  say "  signing $(basename "$app")"
+  # --options runtime is the hardened runtime, and notarisation refuses without
+  # it. --timestamp is what keeps the signature alive past the certificate.
+  codesign --force --options runtime --timestamp --sign "$identity" "$app" >/dev/null 2>&1 ||
+    die "codesign failed on $(basename "$app") in $name.
+The usual cause is a locked keychain, which fails as errSecInternalComponent and
+leaves the file unsigned. Unlock it on the Mac and run this again:
+  security unlock-keychain ~/Library/Keychains/login.keychain-db"
+
+  local actual
+  actual="$(certificate_of "$app")"
+  [ "$actual" = "$PIN" ] ||
+    die "$(basename "$app") was signed by a DIFFERENT certificate
+  expected $PIN
+  got      $actual
+Nothing has been handed back."
+
+  say "  notarising, this takes a few minutes"
+  # Apple takes a zip, a pkg or a dmg, and will not take the tar.gz we publish.
+  # So the zip exists only to carry the bundle there. What gets stapled and
+  # republished is the bundle itself.
+  local zip="${work}/notarise.zip"
+  ( cd "$work" && ditto -c -k --keepParent "$(basename "$app")" "$zip" ) ||
+    die "could not zip $(basename "$app") for notarisation"
+
+  local out
+  out="$(xcrun notarytool submit "$zip" --keychain-profile "$PROFILE" --wait 2>&1)"
+  echo "$out" | grep -q "status: Accepted" ||
+    die "notarisation did not come back Accepted for $name:
+$out"
+  rm -f "$zip"
+
+  say "  stapling"
+  xcrun stapler staple "$app" >/dev/null 2>&1 ||
+    die "the ticket would not staple onto $(basename "$app") in $name"
+
+  # The two questions worth asking after the fact, because a staple that did not
+  # take and a bundle Gatekeeper rejects both look like success up to here.
+  xcrun stapler validate "$app" >/dev/null 2>&1 ||
+    die "$(basename "$app") does not validate against its own ticket"
+  spctl -a -t exec "$app" >/dev/null 2>&1 ||
+    die "Gatekeeper still rejects $(basename "$app") after signing and stapling"
+
+  say "  repacking"
+  rm -f "$archive"
+  # -C and . so the archive keeps the shape it had, symlink included. The
+  # symlink is how a person still types ./tfg instead of reaching into a bundle.
+  tar -czf "$archive" -C "$work" . || die "could not repack $name"
+  rm -rf "$work"
+  say "  done, signed and stapled"
+}
+
+# --------------------------------------------------------------------------- #
+main() {
+  [ -d "$DIR" ] || die "$DIR is not a directory"
+
+  echo "[1/4] the keychain"
+  unlock_keychain
+
+  echo "[2/4] the credentials"
+  check_profile
+
+  echo "[3/4] the certificate"
+  local identity
+  identity="$(find_identity)" || exit 1
+  say "signing with the pinned certificate"
+
+  echo "[4/4] the archives"
+  local archives=()
+  while IFS= read -r line; do
+    archives+=("$line")
+  done < <(find "$DIR" -maxdepth 1 -name '*_macos_*.tar.gz' | sort)
+
+  if [ "${#archives[@]}" -ne 2 ]; then
+    die "expected two macOS archives and found ${#archives[@]}.
+One command line build and one window build carry a macOS program. Signing one
+of two would publish an unsigned binary next to a signed one."
+  fi
+
+  local archive
+  for archive in "${archives[@]}"; do
+    sign_archive "$archive" "$identity"
+  done
+
+  echo
+  echo "Both macOS archives are signed, notarised and stapled."
+}
+
+main "$@"

--- a/.github/scripts/sign_release.py
+++ b/.github/scripts/sign_release.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Sign the Windows binaries of a release with the card, then hand it back.
+"""Sign a release on the two machines that hold its keys, then hand it back.
 
-    python .github/scripts/sign_release.py v0.2.0
+    python .github/scripts/sign_release.py v0.2.0 --macos-host user@mac
     python .github/scripts/sign_release.py v0.2.0 --dry-run   # everything but sign and upload
 
 Why this is a step a person runs
 --------------------------------
-The signing key lives on a cryptographic card in a USB reader and cannot be
+The Windows key lives on a cryptographic card in a USB reader and cannot be
 exported - that is the whole value of it - so no GitHub hosted runner can ever
 reach it. A self hosted runner could, and this is a PUBLIC repository, where a
 self hosted runner is a machine strangers can aim a pull request at. So the build
 happens where builds belong and the signature happens where the card is, and this
 script is the seam between them.
+
+The Apple key is the same problem with a different shape: Apple's notary service
+only talks to credentials held in a keychain, and that keychain is on the owner's
+Mac. So five of the eight archives are signed here, in two places, and the
+checksums are written once at the end over everything.
 
 What it does, in order, and what it refuses
 -------------------------------------------
@@ -25,11 +30,15 @@ What it does, in order, and what it refuses
     unless it hashes to the pin in internal/legal. A second code signing
     certificate on the same machine - a renewal, a test one, one from another
     project - signs just as willingly and the release page looks identical;
- 5. repacks those three archives and writes SHA256SUMS.txt over everything it is
+ 5. hands the two macOS archives to the Mac, which signs the .app bundle inside
+    each one, notarises it with Apple and staples the ticket on. A bare macOS
+    binary cannot be stapled at all, so without this those two archives are
+    refused by Gatekeeper even though they are signed;
+ 6. repacks those archives and writes SHA256SUMS.txt over everything it is
     about to publish, signed and unsigned alike;
- 6. uploads the lot to the DRAFT release and asks attest-release.yml for the
+ 7. uploads the lot to the DRAFT release and asks attest-release.yml for the
     statement about the signed bytes;
- 7. waits for that statement and confirms the draft is complete. Until this
+ 8. waits for that statement and confirms the draft is complete. Until this
     existed in the project this came from, the script ended at "dispatched, go
     look" - and a draft missing one file looks almost exactly like a finished one.
 
@@ -56,6 +65,15 @@ TIMESTAMP_URL = "http://time.certum.pl/"
 # untouched: a Linux or a macOS archive is the finished article here, and the
 # statement the build made about it stays true because its bytes do not move.
 SIGNED_ARCHIVES = ("windows_amd64.zip", "windows_arm64.zip")
+
+# The macOS half. These are signed on the owner's Mac rather than here, because
+# Apple's notary service only talks to credentials held in a keychain there.
+#
+# A bare binary cannot carry a notarisation ticket, measured on 2026-08-28, so
+# the release workflow wraps both macOS binaries in .app bundles and it is the
+# bundle inside each archive that gets signed and stapled.
+MACOS_SUFFIX = "_macos_arm64.tar.gz"
+NOTARY_PROFILE = "tfg-notary"
 
 # Where the pin lives. Read out of the Go source rather than copied here,
 # because two written copies of one digest is exactly the drift this pin exists
@@ -84,13 +102,13 @@ def powershell(script):
     return out.stdout
 
 
-def pinned_digest():
-    """The certificate digest this project signs with, read from the Go source."""
+def pinned_digest(name="CodeSigningSHA256"):
+    """A certificate digest this project signs with, read from the Go source."""
     with open(PIN_FILE, encoding="utf-8") as handle:
         body = handle.read()
-    found = re.search(r'CodeSigningSHA256 = "([0-9a-f]{64})"', body)
+    found = re.search(r'%s = "([0-9a-f]{64})"' % name, body)
     if not found:
-        raise SystemExit("sign_release: no pinned certificate digest in %s" % PIN_FILE)
+        raise SystemExit("sign_release: no %s in %s" % (name, PIN_FILE))
     return found.group(1)
 
 
@@ -296,6 +314,51 @@ def sign_archive(path, thumbprint, pin, signtool, dry_run):
     print("    %s: %s signed and repacked" % (os.path.basename(path), programs[0]))
 
 
+def macos_archives(directory):
+    """The macOS archives, refusing a surprise in the count."""
+    found = [n for n in sorted(os.listdir(directory)) if n.endswith(MACOS_SUFFIX)]
+    if len(found) != 2:
+        raise SystemExit(
+            "sign_release: expected two macOS archives and found %d: %s\n"
+            "One command line build and one window build carry a macOS program. "
+            "Signing one of two would publish an unsigned binary next to a signed one."
+            % (len(found), ", ".join(found) or "none"))
+    return found
+
+
+def sign_macos(tag, directory, host, dry_run):
+    """Hand the macOS archives to the Mac, and take back signed ones.
+
+    Apple's notary service only talks to credentials in a keychain, and the
+    Developer ID key is in one on the owner's Mac. So this half of the signing
+    happens over ssh, the same way the Windows half happens at the card.
+
+    -t because the script over there asks for the keychain password on the
+    terminal. A password given that way is not in argv, so it is not in ps, and
+    it is nowhere in this repository.
+
+    The address of the Mac is an argument rather than a constant. A machine
+    address is not something a public repository should carry.
+    """
+    archives = macos_archives(directory)
+    if dry_run:
+        print("  DRY RUN, would sign %d macOS archive(s) on %s"
+              % (len(archives), host))
+        return
+    remote = "tfg-signing-%s" % tag
+    run(["ssh", host, "rm -rf %s && mkdir -p %s/dist" % (remote, remote)])
+    run(["scp", os.path.join(".github", "scripts", "sign_macos.sh"),
+         "%s:%s/" % (host, remote)])
+    for name in archives:
+        run(["scp", os.path.join(directory, name), "%s:%s/dist/" % (host, remote)])
+    run(["ssh", "-t", host, "bash %s/sign_macos.sh %s/dist %s %s"
+         % (remote, remote, pinned_digest("AppleDeveloperIDSHA256"), NOTARY_PROFILE)])
+    for name in archives:
+        run(["scp", "%s:%s/dist/%s" % (host, remote, name), directory])
+    run(["ssh", host, "rm -rf %s" % remote])
+    print("  %d macOS archive(s) signed, notarised and stapled" % len(archives))
+
+
 def name_for_publication(directory, tag):
     """Give the build's own files the names a person will see, or drop them.
 
@@ -400,37 +463,52 @@ def main(argv=None):
                         help="everything except signing, uploading and dispatching")
     parser.add_argument("--wait", type=int, default=300,
                         help="seconds to wait for the statement (default 300)")
+    parser.add_argument("--macos-host", default=os.environ.get("TFG_MACOS_HOST"),
+                        help="user@host of the Mac that signs the macOS archives, "
+                             "or set TFG_MACOS_HOST")
     args = parser.parse_args(argv)
 
     if not os.path.isfile(PIN_FILE):
         raise SystemExit("sign_release: run this from the root of the repository")
+    # Refused here rather than after the Windows half, because stopping halfway
+    # would leave a build with three signed archives and two unsigned ones, and
+    # a release page cannot say that.
+    if not args.macos_host:
+        raise SystemExit(
+            "sign_release: no Mac to sign the macOS archives on.\n"
+            "Pass --macos-host user@host, or set TFG_MACOS_HOST.\n"
+            "A bare macOS binary cannot carry a notarisation ticket, so those two\n"
+            "archives are rejected by Gatekeeper unless this step runs.")
     pin = pinned_digest()
     work = os.path.join("dist", "signing", args.tag)
 
-    print("\n[1/7] fetching the build for %s" % args.tag)
+    print("\n[1/8] fetching the build for %s" % args.tag)
     fetch_build(args.tag, work)
 
-    print("\n[2/7] checking it before touching it")
+    print("\n[2/8] checking it before touching it")
     verify_before_touching(work)
 
-    print("\n[3/7] the card")
+    print("\n[3/8] the card")
     thumbprint = signing_thumbprint(pin)
     signtool = find_signtool()
 
-    print("\n[4/7] signing the Windows programs")
+    print("\n[4/8] signing the Windows programs")
     for name in windows_archives(work):
         sign_archive(os.path.join(work, name), thumbprint, pin, signtool, args.dry_run)
 
-    print("\n[5/7] checksums over what will be published")
+    print("\n[5/8] signing the macOS bundles on %s" % args.macos_host)
+    sign_macos(args.tag, work, args.macos_host, args.dry_run)
+
+    print("\n[6/8] checksums over what will be published")
     name_for_publication(work, args.tag)
     digest = write_checksums(work)
     print("  SHA256SUMS.txt: %s" % digest)
 
-    print("\n[6/7] uploading to the draft")
+    print("\n[7/8] uploading to the draft")
     upload_to_draft(args.tag, work, args.dry_run)
     ask_for_the_statement(args.tag, digest, args.dry_run)
 
-    print("\n[7/7] waiting for the statement and checking the draft")
+    print("\n[8/8] waiting for the statement and checking the draft")
     confirm_draft(args.tag, args.wait, args.dry_run)
 
     print("\nDone. %s is a complete DRAFT." % args.tag)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,15 @@ jobs:
             # it - see THIRD-PARTY-NOTICES.md, which says so itself. The licence
             # and the readme go along for the person who downloaded an archive
             # and nothing else.
+            # macOS gets a .app bundle, and it is not decoration: a bare binary
+            # cannot carry a notarisation ticket at all, so Gatekeeper rejects
+            # it even after it is signed and notarised. Measured 2026-08-28.
+            # A symlink goes in beside it, so a person still types ./tfg.
+            if [ "$os" = "darwin" ]; then
+              .github/scripts/make_app_bundle.sh \
+                "${work}" "${binary}" "com.donislawdev.tfg" "${version}"
+            fi
+
             cp LICENSE THIRD-PARTY-NOTICES.md README.md "${work}/"
 
             base="tfg_${version}_${label}_${arch}"
@@ -290,6 +299,13 @@ jobs:
               -o "${work}/tfg-gui.exe" ./cmd/tfg-gui
           else
             go build -trimpath -o "${work}/tfg-gui" ./cmd/tfg-gui
+          fi
+
+          # Same reason as the command line archives: on macOS the ticket has
+          # nowhere to attach unless the binary is inside a bundle.
+          if [ "$os" = "darwin" ]; then
+            .github/scripts/make_app_bundle.sh \
+              "${work}" "tfg-gui" "com.donislawdev.tfg-gui" "${version}"
           fi
 
           cp LICENSE THIRD-PARTY-NOTICES.md README.md "${work}/"
@@ -424,11 +440,16 @@ jobs:
             echo "carries a timestamp, and names \`Open Source Developer Dominik Babiarz\`, issued by"
             echo "Certum. Windows checks it when you run the program."
             echo
-            echo "**macOS and Linux binaries are not signed yet.**"
+            echo "**macOS binaries are signed and notarised by Apple.** The program lives inside"
+            echo "\`tfg.app\` or \`tfg-gui.app\`, with a link called \`tfg\` or \`tfg-gui\` next to it, so"
+            echo "you can still type \`./tfg\`. macOS opens them without complaining, and without"
+            echo "asking the network, because the notarisation ticket travels inside the bundle."
             echo
-            echo "- **macOS** refuses to open it on the first try. Open it from the right click menu,"
-            echo "  or allow it in System Settings under Privacy and Security."
-            echo "- **Linux** says nothing, but you may need \`chmod +x\`."
+            echo "> Keep the \`.app\` and the link together. A copy of the program taken out of the"
+            echo "> bundle on its own is refused, because the signature covers the bundle."
+            echo
+            echo "**Linux binaries are not signed.** Linux says nothing about that, but you may"
+            echo "need \`chmod +x\`."
             echo
             echo "## What you can check without trusting this page"
             echo
@@ -442,16 +463,22 @@ jobs:
             echo "The predicate type has to be given. \`gh\` asks for build provenance unless told"
             echo "otherwise, and that is a different statement - see below."
             echo
-            echo "Where a **macOS or Linux** archive came from. These are exactly the bytes the"
-            echo "build produced, so the build's own statement still describes them:"
+            echo "Where a **Linux** archive came from. These are exactly the bytes the build"
+            echo "produced, so the build's own statement still describes them:"
             echo
             echo "\`\`\`"
             echo "gh attestation verify <the file you downloaded> -R ${GITHUB_REPOSITORY}"
             echo "\`\`\`"
             echo
-            echo "That one does not answer for a **Windows** archive, and deliberately: a person"
-            echo "signed those on their own machine after the build, so the bytes are no longer the"
-            echo "bytes the runner made. Their signature is the Authenticode one above."
+            echo "That one does not answer for a **Windows or macOS** archive, and deliberately: a"
+            echo "person signed those on their own machines after the build, so the bytes are no"
+            echo "longer the bytes the runner made. What answers for them is the signature itself -"
+            echo "Authenticode on Windows, and on macOS:"
+            echo
+            echo "\`\`\`"
+            echo "spctl -a -vv tfg.app          # what Gatekeeper thinks of it"
+            echo "xcrun stapler validate tfg.app  # that the ticket is really in the file"
+            echo "\`\`\`"
             echo
             echo "The \`.spdx.json\` file lists every library and every font compiled into these"
             echo "binaries, with its licence. The \`.sigstore.json\` files are the statements"
@@ -497,11 +524,15 @@ jobs:
           set -euo pipefail
           echo "Built, attested, and opened as an EMPTY DRAFT."
           echo
-          echo "Nothing is published yet. On the machine with the card:"
+          echo "Nothing is published yet. On the machine with the card, with the Mac awake:"
           echo
-          echo "    python .github/scripts/sign_release.py ${GITHUB_REF_NAME}"
+          echo "    python .github/scripts/sign_release.py ${GITHUB_REF_NAME} --macos-host user@mac"
           echo
           echo "That verifies this build's provenance before touching it, signs the three"
-          echo "Windows binaries with the card, writes SHA256SUMS.txt over what it made,"
-          echo "uploads everything to the draft and asks attest-release.yml for the statement"
-          echo "about the signed bytes. Then read the draft and publish it."
+          echo "Windows binaries with the card, hands the two macOS archives to the Mac to be"
+          echo "signed, notarised and stapled, writes SHA256SUMS.txt over what it made, uploads"
+          echo "everything to the draft and asks attest-release.yml for the statement about the"
+          echo "signed bytes. Then read the draft and publish it."
+          echo
+          echo "It refuses without a Mac rather than publishing five signed archives and two"
+          echo "that Gatekeeper will turn away."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -344,6 +344,25 @@ because it turns other people's test suites red.
 
 ### Changed
 
+- **macOS downloads are signed by the owner and notarised by Apple, and macOS
+  opens them without argument.** They used to be refused on the first try, with
+  a note here telling you to open them from the right click menu instead. That
+  note is gone because the reason for it is gone, and it works with the network
+  off as well - the notarisation travels inside the file rather than being
+  looked up.
+
+  The archive has a different shape because of it. The program now lives inside
+  `tfg.app` or `tfg-gui.app`, with a link called `tfg` or `tfg-gui` beside it,
+  so `./tfg` still works exactly as before. Keep the two together: a copy of the
+  program lifted out of the bundle on its own is refused, because the signature
+  covers the bundle rather than the file.
+
+  One thing this takes away, and it is written down rather than left to be
+  discovered. The build's own statement about where a file came from no longer
+  answers for the macOS archives, because signing them changes their bytes. It
+  still answers for Linux. What answers for macOS is the signature itself, and
+  the release notes say which two commands read it.
+
 - The window no longer offers to put files inside a format that holds none.
   "Add files inside" now appears under ZIP and TAR.GZ, and nowhere else. It used
   to appear under every batch, so a PNG batch carried a button whose only

--- a/internal/guard/macossigning_test.go
+++ b/internal/guard/macossigning_test.go
@@ -1,0 +1,224 @@
+package guard
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/donislawdev/TestingFilesGenerator/internal/legal"
+)
+
+// macOS is signed on a second machine, and every guard here is about a failure
+// that is quiet rather than loud.
+//
+// The measurements these stand on were taken on 2026-08-28, on a real Developer
+// ID certificate and two real notarisations:
+//
+//   - a bare Mach-O binary CANNOT be stapled. stapler exits 66 and says it is
+//     "incapable of working with Document files", and Gatekeeper then rejects
+//     the binary even though it is signed AND notarised. So the bundle is not
+//     packaging taste, it is the only shape a ticket attaches to;
+//   - a .dmg staples and does not help - the binary inside a stapled dmg is
+//     still rejected, because the ticket describes the container;
+//   - a copy of the binary taken out of the bundle is rejected with "invalid
+//     resource directory", so the link beside the bundle has to be a link;
+//   - the ticket survives tar.gz, which is why the archive names on the site
+//     did not have to change.
+//
+// Each of those is a way to ship something that looks signed and is refused on
+// the first machine that downloads it.
+
+func macSigningScript(t *testing.T) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(repoRoot(t), ".github", "scripts", "sign_macos.sh"))
+	if err != nil {
+		t.Skipf("no macOS signing script here: %v", err)
+	}
+	return string(body)
+}
+
+func bundleScript(t *testing.T) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(repoRoot(t), ".github", "scripts", "make_app_bundle.sh"))
+	if err != nil {
+		t.Skipf("no bundle script here: %v", err)
+	}
+	return string(body)
+}
+
+// The release has to BUILD a bundle, or there is nothing to staple.
+//
+// This is the guard the whole macOS half rests on. Without a bundle the signing
+// script still runs, still signs, still notarises - and produces archives that
+// Gatekeeper turns away, because a ticket has nowhere to go on a bare binary.
+func TestTheReleaseWrapsTheMacBinariesInBundles(t *testing.T) {
+	workflow := withoutYamlComments(workflowText(t, "release.yml"))
+
+	if !strings.Contains(workflow, "make_app_bundle.sh") {
+		t.Fatal("the release workflow never calls make_app_bundle.sh, so the macOS " +
+			"archives carry bare binaries - which cannot be stapled at all, and are " +
+			"rejected by Gatekeeper even after they are signed and notarised")
+	}
+	// Both of them. One command line binary and one window binary reach macOS,
+	// and wrapping one of two would publish a rejected program beside a working
+	// one - which is the shape of failure that is hardest to notice.
+	calls := strings.Count(workflow, "make_app_bundle.sh")
+	if calls < 2 {
+		t.Errorf("make_app_bundle.sh is called %d time(s) and both the command line "+
+			"binary and the window binary need it", calls)
+	}
+	for _, id := range []string{"com.donislawdev.tfg", "com.donislawdev.tfg-gui"} {
+		if !strings.Contains(workflow, id) {
+			t.Errorf("no bundle identifier %q in the release workflow", id)
+		}
+	}
+}
+
+// A link beside the bundle has to be a LINK.
+//
+// ln makes a copy without complaining on a filesystem that cannot do symlinks,
+// and a copy here is worse than nothing: it looks like the program, it is the
+// right size, and Gatekeeper refuses it. Measured by accident - a build on
+// Windows produced exactly this, and the archive doubled in size.
+func TestTheLinkBesideTheBundleCannotBeACopy(t *testing.T) {
+	script := bundleScript(t)
+	if !strings.Contains(script, "-L ") {
+		t.Error("make_app_bundle.sh never checks that what it made is a symlink, " +
+			"so a filesystem without symlinks turns it into a copy of the binary - " +
+			"and a copy outside the bundle is rejected by Gatekeeper")
+	}
+	if !strings.Contains(script, "ln -s") {
+		t.Error("make_app_bundle.sh does not put a link beside the bundle, so a person " +
+			"has to reach inside a .app to run a command line tool")
+	}
+}
+
+// The pin is a digest with a date, and the script derives its selector from it.
+//
+// Same shape as the Windows pin and for the same reason: codesign selects by
+// SHA-1, SHA-1 is not worth pinning anything to, and two written copies of one
+// certificate identity is exactly the drift a pin exists to catch.
+func TestThePinnedAppleCertificateIsADigestWithADate(t *testing.T) {
+	if !regexp.MustCompile(`^[0-9a-f]{64}$`).MatchString(legal.AppleDeveloperIDSHA256) {
+		t.Errorf("the pinned Apple certificate is %q, which is not a sha256",
+			legal.AppleDeveloperIDSHA256)
+	}
+	expires, err := time.Parse("2006-01-02", legal.AppleDeveloperIDExpires)
+	if err != nil {
+		t.Fatalf("the Apple certificate expiry %q is not a date: %v",
+			legal.AppleDeveloperIDExpires, err)
+	}
+	t.Logf("the pinned Apple certificate expires %s", expires.Format("2006-01-02"))
+
+	if !strings.Contains(signingScript(t), "AppleDeveloperIDSHA256") {
+		t.Error("the signing script does not read the Apple pin from internal/legal, " +
+			"so there are two written copies of one digest")
+	}
+}
+
+// The script refuses before it signs, and refuses after it signs.
+//
+// Before: no profile, and a certificate that is not the pinned one. After:
+// notarisation that did not come back Accepted, a staple that did not take, and
+// a bundle Gatekeeper still rejects. The last three matter because every one of
+// them leaves a file that looks finished.
+func TestTheMacSigningScriptRefusesOnBothSidesOfSigning(t *testing.T) {
+	script := macSigningScript(t)
+
+	for _, want := range []struct{ needle, why string }{
+		{"store-credentials",
+			"a missing notarytool profile has to say how to create one"},
+		{"hashes to the pin",
+			"a certificate that is not the pinned one has to stop the run"},
+		{"status: Accepted",
+			"notarisation that came back anything else has to stop the run"},
+		{"stapler validate",
+			"a staple that did not take looks exactly like one that did"},
+		{"spctl",
+			"the last question is whether Gatekeeper actually accepts it, and " +
+				"without asking, the script hands back an archive that fails on " +
+				"the first machine that downloads it"},
+	} {
+		if !strings.Contains(script, want.needle) {
+			t.Errorf("sign_macos.sh does not mention %q: %s", want.needle, want.why)
+		}
+	}
+
+	// The hardened runtime, without which Apple refuses to notarise, and the
+	// timestamp, without which the signature dies with the certificate.
+	if !strings.Contains(script, "--options runtime") {
+		t.Error("sign_macos.sh does not sign with the hardened runtime, and Apple " +
+			"refuses to notarise anything signed without it")
+	}
+	if !strings.Contains(script, "--timestamp") {
+		t.Error("sign_macos.sh signs without a timestamp, so those signatures die " +
+			"when the certificate expires instead of outliving it")
+	}
+}
+
+// A release is signed on two machines or it is not published.
+//
+// Stopping after the Windows half would leave three signed archives and two that
+// Gatekeeper turns away, on one page, looking alike. So the absence of a Mac is
+// a refusal at the very start rather than a warning in the middle.
+func TestTheReleaseWillNotBeSignedOnOneMachineOnly(t *testing.T) {
+	script := signingScript(t)
+
+	// The call, not the name. "sign_macos" appears in a def and in prose, so
+	// asking whether the name is anywhere would pass a script that defines the
+	// step and never runs it.
+	if !strings.Contains(script, "sign_macos(args.tag") {
+		t.Error("sign_release.py never calls the macOS signing step, so those two " +
+			"archives go out unsigned beside signed Windows ones")
+	}
+	// And the refusal, in its own words. Without it the script would sign the
+	// Windows half and publish the macOS half unsigned, which is the one
+	// outcome a release page cannot explain.
+	if !strings.Contains(script, "no Mac to sign the macOS archives on") {
+		t.Error("sign_release.py does not refuse when there is no Mac, so it would " +
+			"publish three signed archives and two Gatekeeper turns away")
+	}
+	// The address of the Mac has to come from outside the file. Not checked
+	// here that no address is written down anywhere - privatecontent_test.go
+	// already asks that of every tracked file AND of the git history, and asks
+	// it better: it names the private ranges instead of matching four numbers
+	// with dots, which is why it does not mistake the certificate OID
+	// 1.3.6.1.5.5.7.3.3 for an address. This one did, before it was deleted.
+	if !strings.Contains(script, "TFG_MACOS_HOST") {
+		t.Error("sign_release.py offers no way to name the Mac from outside the file, " +
+			"so the address would have to be written into a public repository")
+	}
+}
+
+// The release notes cannot go on saying macOS is unsigned.
+//
+// This is the same class as the guard over the site: prose nobody checks goes
+// stale the moment the thing it describes changes, and a note telling people to
+// right click their way past Gatekeeper is worse than useless once the binary
+// opens normally.
+func TestTheReleaseNotesDoNotCallTheMacBinariesUnsigned(t *testing.T) {
+	workflow := workflowText(t, "release.yml")
+	notes := workflow
+	if at := strings.Index(workflow, "## Signing"); at >= 0 {
+		notes = workflow[at:]
+	}
+
+	if strings.Contains(notes, "macOS and Linux binaries are not signed") {
+		t.Error("the release notes still say the macOS binaries are unsigned, and " +
+			"they are signed, notarised and stapled")
+	}
+	if strings.Contains(notes, "macOS** refuses to open it on the first try") {
+		t.Error("the release notes still tell people to right click past Gatekeeper, " +
+			"which is advice for a binary this release no longer publishes")
+	}
+	// And the build's own statement stops describing the macOS archives the
+	// moment a person signs them, because signing moves the bytes.
+	if strings.Contains(notes, "Where a **macOS or Linux** archive came from") {
+		t.Error("the release notes still offer the build's provenance for macOS " +
+			"archives, and signing changed those bytes, so that check now fails " +
+			"for anybody who runs it")
+	}
+}

--- a/internal/legal/codesign.go
+++ b/internal/legal/codesign.go
@@ -38,3 +38,29 @@ const CodeSigningSHA256 = "47b79ad3cfa53ef846cad03a59148f8c981d0b1196891e48b8c8d
 // 3161 timestamp, and without one a signature dies with its certificate - but
 // nothing new can be signed past this date.
 const CodeSigningExpires = "2027-08-19"
+
+// AppleDeveloperIDSHA256 is the SHA-256 of the DER bytes of the Developer ID
+// Application certificate this project signs macOS bundles with.
+//
+// Read off the Mac on 2026-08-28, issued by Apple's Developer ID Certification
+// Authority. The same certificate sits in two keychains on that machine, the
+// login one and the system one, so "sign with Developer ID Application" is an
+// ambiguous instruction and the digest is what makes it unambiguous.
+//
+// Why a digest here and a SHA-1 at signing time: codesign selects a certificate
+// by SHA-1, and SHA-1 is not a digest worth pinning anything to. The signing
+// step hashes every identity it can see and picks the one matching this, so the
+// selector is derived rather than written down twice.
+//
+// Nothing about the certificate's subject is written here. It carries the
+// owner's name and Apple team, both of which become public the first time a
+// signed macOS release goes out, and that is a thing to say out loud once
+// rather than to spread through a repository.
+const AppleDeveloperIDSHA256 = "c656a279aba94f535d6fcf9aff1ce05cd51295aea52295677ae5e1f1d7d77794"
+
+// AppleDeveloperIDExpires is when that certificate stops being able to sign.
+//
+// Signatures outlive it, because every one this project makes carries a
+// timestamp, and notarisation tickets are issued by Apple rather than by the
+// certificate. Nothing new can be signed past this date.
+const AppleDeveloperIDExpires = "2029-10-27"


### PR DESCRIPTION
macOS downloads were refused by Gatekeeper on the first try, with a note in the release telling people to right click past it. They are now signed with a Developer ID certificate, notarised by Apple and stapled, so macOS opens them without argument and without asking the network.

## What the measurement forced

Taken on a real Mac, on a real certificate, with four real notarisations that came back `Accepted`. The verdict is in the exit code of `stapler`, where **66 means wrong format and 65 means right format, missing ticket**. Without that distinction every candidate looks identical, because they all refuse.

| candidate | stapling | Gatekeeper | verdict |
|---|---|---|---|
| bare binary *(what we published)* | **66** | **3, rejected** | cannot be done |
| `.zip` | **66** | - | cannot be done |
| `.dmg` | **0** | dmg yes, **binary inside 3** | does not help |
| **`.app`** | **0** | **0, accepted** | the only one |

Three things this settled that would otherwise have been guessed:

- **Signing alone does not lift the refusal.** Signed with Developer ID, `codesign --verify` clean, chain to Apple Root CA, and `spctl` still says rejected. Notarisation is required, not advisable.
- **`.dmg` is the misleading one.** The stapled dmg passes; the binary inside it, and any copy of it, does not.
- **The ticket survives `tar.gz`.** So the archive names on the release page did not have to change, and the site guard was not touched.

## What changed

Both macOS binaries now travel inside a bundle with a link beside them, so `./tfg` still works. The link has to be a link: `ln` quietly makes a copy on a filesystem without symlinks, and a copy outside the bundle is rejected with "invalid resource directory". `make_app_bundle.sh` refuses rather than shipping one - found by accident, when a build on Windows produced exactly that.

Signing happens on the Mac, because Apple's notary service only talks to credentials in a keychain there. `sign_release.py` hands the two archives over by ssh and takes signed ones back, and **refuses outright when there is no Mac** - stopping halfway would publish three signed archives beside two Gatekeeper turns away, on one page, looking alike. The Mac's address is an argument rather than a constant.

The certificate is pinned by the digest of its own bytes, like the Windows one. The same certificate is installed in two keychains on that machine, so the name alone names two entries.

The release notes lose three sentences that stopped being true. The worst was the one offering the build's provenance for macOS archives: signing moves the bytes, so that command now fails for anybody who runs it on a macOS download.

## Guards

Six, each proven by mutation - all six caught. They cover the bundle being built at all, the link not being a copy, the pin being a digest with a date, the script refusing on both sides of signing, the release refusing to be signed on one machine only, and the notes no longer calling macOS unsigned.

One guard was deleted during review rather than kept: it checked that no machine address is written down, which `privatecontent_test.go` already does, better - by naming the private ranges, so it does not mistake the certificate OID `1.3.6.1.5.5.7.3.3` for an address. Mine did.

## Not measured, said out loud

- **Behaviour with no network.** The ticket is in the file and `stapler validate` reads it locally, but no run with the network cut was done, because cutting it cuts ssh too.
- **The real window binary on macOS.** All of this ran on the command line binary - the Mac has no Go, and the window needs CGO.
- **The bundle has no icon.** The project has `.ico` and PNG, no `.icns`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)