### PR TITLE
The download list ends with the things you check a download with

### DIFF
--- a/.github/scripts/sign_release.py
+++ b/.github/scripts/sign_release.py
@@ -34,8 +34,8 @@ What it does, in order, and what it refuses
     each one, notarises it with Apple and staples the ticket on. A bare macOS
     binary cannot be stapled at all, so without this those two archives are
     refused by Gatekeeper even though they are signed;
- 6. repacks those archives and writes SHA256SUMS.txt over everything it is
-    about to publish, signed and unsigned alike;
+ 6. repacks those archives and writes verify-SHA256SUMS.txt over everything it
+    is about to publish, signed and unsigned alike;
  7. uploads the lot to the DRAFT release and asks attest-release.yml for the
     statement about the signed bytes;
  8. waits for that statement and confirms the draft is complete. Until this
@@ -74,6 +74,21 @@ SIGNED_ARCHIVES = ("windows_amd64.zip", "windows_arm64.zip")
 # bundle inside each archive that gets signed and stapled.
 MACOS_SUFFIX = "_macos_arm64.tar.gz"
 NOTARY_PROFILE = "tfg-notary"
+
+# The four files a person uses to CHECK a download, rather than download itself.
+#
+# The prefix is the only thing that puts them at the end of the release page.
+# Measured on 2026-08-28 against a draft release: GitHub orders the download
+# list ALPHABETICALLY BY FILE NAME and nothing else moves it - not the upload
+# order, not the asset id, not the label, and the sort ignores letter case.
+# Without a prefix SHA256SUMS.txt sorts FIRST, above every archive, and the
+# .json files land in the middle, between the window archives and the command
+# line ones, because a dot sorts before an underscore.
+#
+# verify- rather than a number, because the word is true: these four are what
+# you verify a download with. A number would sort just as well and would say
+# nothing.
+AUX_PREFIX = "verify-"
 
 # Where the pin lives. Read out of the Go source rather than copied here,
 # because two written copies of one digest is exactly the drift this pin exists
@@ -363,32 +378,34 @@ def name_for_publication(directory, tag):
     """Give the build's own files the names a person will see, or drop them.
 
     build.sha256 was the subject list for the statement the runner made. It
-    describes three archives that no longer exist in that form, so publishing it
-    beside SHA256SUMS.txt would put two lists of checksums on one page and one of
+    describes archives that no longer exist in that form, so publishing it beside
+    the real checksum file would put two lists of checksums on one page and one of
     them would be wrong about half the files.
 
     The provenance bundle does stay, under a name a person can use: it still
     describes the five archives nothing signed, byte for byte.
     """
     build_sums = os.path.join(directory, "build.sha256")
+    # Not renamed and not published: this one names bytes that no longer exist
+    # in that form, and it is deleted just below.
     if os.path.isfile(build_sums):
         os.remove(build_sums)
     made = os.path.join(directory, "build.provenance.sigstore.json")
     if os.path.isfile(made):
         os.rename(made, os.path.join(
-            directory, "tfg_%s.provenance.sigstore.json" % tag.lstrip("v")))
+            directory, "verify-tfg_%s.provenance.sigstore.json" % tag.lstrip("v")))
 
 
 def write_checksums(directory):
-    """SHA256SUMS.txt over what is about to be published, and its own digest."""
+    """The checksum file over what is about to be published, and its own digest."""
     published = sorted(os.listdir(directory))
     lines = []
     for name in published:
         lines.append("%s  %s\n" % (sha256_of(os.path.join(directory, name)), name))
-    sums = os.path.join(directory, "SHA256SUMS.txt")
+    sums = os.path.join(directory, AUX_PREFIX + "SHA256SUMS.txt")
     with open(sums, "w", encoding="utf-8", newline="\n") as handle:
         handle.writelines(lines)
-    print("  %d file(s) listed in SHA256SUMS.txt" % len(published))
+    print("  %d file(s) listed in %sSHA256SUMS.txt" % (len(published), AUX_PREFIX))
     return sha256_of(sums)
 
 
@@ -441,9 +458,13 @@ def confirm_draft(tag, wait_seconds, dry_run):
     missing = []
     if sum(1 for n in names if n.endswith((".zip", ".tar.gz"))) != 8:
         missing.append("eight archives")
-    for needed in ("SHA256SUMS.txt", ".spdx.json", ".sbom.sigstore.json",
-                   ".provenance.sigstore.json"):
-        if not any(n.endswith(needed) or n == needed for n in names):
+    # Each of the four is asked for WITH its prefix, not by suffix alone. A
+    # suffix would be happy with a file the prefix fell off, and the prefix is
+    # the only thing keeping these four at the end of the download list.
+    for needed in (AUX_PREFIX + "SHA256SUMS.txt", ".spdx.json",
+                   ".sbom.sigstore.json", ".provenance.sigstore.json"):
+        if not any((n.startswith(AUX_PREFIX) and n.endswith(needed)) or n == needed
+                   for n in names):
             missing.append(needed)
     if missing:
         raise SystemExit(
@@ -502,7 +523,7 @@ def main(argv=None):
     print("\n[6/8] checksums over what will be published")
     name_for_publication(work, args.tag)
     digest = write_checksums(work)
-    print("  SHA256SUMS.txt: %s" % digest)
+    print("  %sSHA256SUMS.txt: %s" % (AUX_PREFIX, digest))
 
     print("\n[7/8] uploading to the draft")
     upload_to_draft(args.tag, work, args.dry_run)

--- a/.github/workflows/attest-release.yml
+++ b/.github/workflows/attest-release.yml
@@ -25,7 +25,7 @@ on:
         description: "The release tag, for example v0.2.0"
         required: true
       digest:
-        description: "sha256 of SHA256SUMS.txt, as sign_release.py printed it"
+        description: "sha256 of verify-SHA256SUMS.txt, as sign_release.py printed it"
         required: true
 
 permissions:
@@ -57,8 +57,8 @@ jobs:
           mkdir -p signed
           cd signed
           gh release download "$TAG" --pattern '*.zip' --pattern '*.tar.gz' \
-            --pattern '*.spdx.json' --pattern 'SHA256SUMS.txt'
-          actual="$(sha256sum SHA256SUMS.txt | cut -d' ' -f1)"
+            --pattern '*.spdx.json' --pattern 'verify-SHA256SUMS.txt'
+          actual="$(sha256sum verify-SHA256SUMS.txt | cut -d' ' -f1)"
           echo "the release carries: $actual"
           if [ "$actual" != "$CLAIMED" ]; then
             echo "::error::the checksums file on the release hashes to $actual, but this run"
@@ -67,10 +67,10 @@ jobs:
           fi
           # And the checksums have to describe the files that came with them,
           # because everything below is a statement about that list.
-          sha256sum -c SHA256SUMS.txt
+          sha256sum -c verify-SHA256SUMS.txt
           sbom="$(ls -- *.spdx.json)"
           echo "SBOM=signed/${sbom}" >> "$GITHUB_ENV"
-          echo "SUMS=signed/SHA256SUMS.txt" >> "$GITHUB_ENV"
+          echo "SUMS=signed/verify-SHA256SUMS.txt" >> "$GITHUB_ENV"
 
       # The bill of materials, bound to the files a person actually downloads.
       # Before the signature existed this binding was made at build time. It is
@@ -127,7 +127,11 @@ jobs:
         # offline, from a mirror, from anywhere.
         run: |
           set -euo pipefail
-          name="tfg_${TAG#v}.sbom.sigstore.json"
+          # verify- so it lands at the end of the download list with the other
+          # three files a person checks a download against, rather than in the
+          # middle of the archives. GitHub sorts that list by file name and by
+          # nothing else - measured 2026-08-28.
+          name="verify-tfg_${TAG#v}.sbom.sigstore.json"
           cp "$BUNDLE" "$name"
           python3 -c "import json,sys; json.load(open(sys.argv[1])); print('the bundle parses as JSON')" "$name"
           gh release upload "$TAG" "$name" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,10 +366,18 @@ jobs:
         run: |
           set -euo pipefail
           version="${{ needs.check.outputs.version }}"
+          # verify- rather than tfg-, and the prefix is doing one job: GitHub
+          # sorts a release's downloads ALPHABETICALLY BY FILE NAME, and nothing
+          # else moves them. Measured on 2026-08-28 against a draft release: not
+          # the upload order, not the asset id, not the label, and the sort
+          # ignores letter case. Without the prefix this file lands BETWEEN the
+          # window archives and the command line ones, because a dot sorts
+          # before an underscore. With it, the four files a person uses to check
+          # a download sit together at the end, under the things they check.
           go run ./internal/legal/cmd/sbom \
             -seed "${GITHUB_REF_NAME}" \
-            -o "incoming/tfg_${version}.spdx.json"
-          echo "SBOM=incoming/tfg_${version}.spdx.json" >> "$GITHUB_ENV"
+            -o "incoming/verify-tfg_${version}.spdx.json"
+          echo "SBOM=incoming/verify-tfg_${version}.spdx.json" >> "$GITHUB_ENV"
 
       - name: one list of what this build produced
         # build.sha256 rather than SHA256SUMS.txt, and the difference is the
@@ -432,7 +440,7 @@ jobs:
             echo "- \`tfg-gui_*\` is the desktop window. Same engine, same features."
             echo
             echo "Match the file to your system and architecture. Check what you downloaded against"
-            echo "\`SHA256SUMS.txt\`."
+            echo "\`verify-SHA256SUMS.txt\`, at the bottom of this list."
             echo
             echo "## Signing"
             echo
@@ -480,7 +488,9 @@ jobs:
             echo "xcrun stapler validate tfg.app  # that the ticket is really in the file"
             echo "\`\`\`"
             echo
-            echo "The \`.spdx.json\` file lists every library and every font compiled into these"
+            echo "The four files whose names start with \`verify-\` are the ones you check a"
+            echo "download against, and they sit together at the bottom of the list. The"
+            echo "\`.spdx.json\` file lists every library and every font compiled into these"
             echo "binaries, with its licence. The \`.sigstore.json\` files are the statements"
             echo "themselves, so both commands also work offline with \`--bundle\`."
             echo

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -188,7 +188,10 @@ jobs:
           archives="$(ls -1 -- *.zip *.tar.gz 2>/dev/null | wc -l)"
           echo "archives: $archives"
           test "$archives" = "8" || { echo "expected eight archives"; exit 1; }
-          for needed in SHA256SUMS.txt *.spdx.json *.provenance.sigstore.json *.sbom.sigstore.json; do
+          # Named with the verify- prefix rather than by suffix alone, because
+          # the prefix is the only thing keeping these four at the end of the
+          # download list, and a suffix is happy with a file that lost it.
+          for needed in verify-SHA256SUMS.txt verify-*.spdx.json verify-*.provenance.sigstore.json verify-*.sbom.sigstore.json; do
             ls -1 -- $needed >/dev/null || { echo "missing: $needed"; exit 1; }
           done
           echo "every expected asset is published"
@@ -198,7 +201,7 @@ jobs:
         working-directory: published
         run: |
           set -euo pipefail
-          sha256sum -c SHA256SUMS.txt
+          sha256sum -c verify-SHA256SUMS.txt
 
       - name: the two commands the notes tell people to run
         shell: bash
@@ -286,7 +289,7 @@ jobs:
         run: |
           set -euo pipefail
           gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body --jq .body > notes.md
-          for promised in "gh attestation verify" "--predicate-type https://spdx.dev/Document" "SHA256SUMS.txt"; do
+          for promised in "gh attestation verify" "--predicate-type https://spdx.dev/Document" "verify-SHA256SUMS.txt"; do
             grep -qF -- "$promised" notes.md || {
               echo "the release notes never mention: $promised"
               echo "This job just ran it, so the page and the check disagree about what a person should do."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -344,6 +344,21 @@ because it turns other people's test suites red.
 
 ### Changed
 
+- **The four files you check a download against now sit together at the bottom
+  of the release page, and their names say so.** `SHA256SUMS.txt` is now
+  `verify-SHA256SUMS.txt`, and the `.spdx.json` and two `.sigstore.json` files
+  gained the same `verify-` prefix.
+
+  Nothing about what they contain changed. What changed is where they appear:
+  GitHub orders a release's download list alphabetically by file name and by
+  nothing else, so the old names put the checksums file at the very top, above
+  every program, and dropped the three statement files into the middle of the
+  list between the desktop archives and the command line ones. Now the programs
+  come first and the things you check them with come last.
+
+  If you have a script that fetches `SHA256SUMS.txt` by name, it needs the new
+  name from the next release on. The release notes carry it too.
+
 - **macOS downloads are signed by the owner and notarised by Apple, and macOS
   opens them without argument.** They used to be refused on the first try, with
   a note here telling you to open them from the right click menu instead. That

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,7 +54,7 @@ through a symbolic link, are refused.
 
 **The released binaries are not signed.** Signing is not set up, the release notes
 say so, and your operating system will warn you. Verify a download against
-`SHA256SUMS.txt` from the same release.
+`verify-SHA256SUMS.txt` from the same release.
 
 ### In scope
 

--- a/internal/guard/attestation_test.go
+++ b/internal/guard/attestation_test.go
@@ -114,7 +114,7 @@ func TestTheReleaseMakesItsDocumentAndHandsItOver(t *testing.T) {
 
 	for what, want := range map[string]string{
 		"the bill of materials is generated":           "go run ./internal/legal/cmd/sbom",
-		"it is written where the build is handed over": "-o \"incoming/tfg_${version}.spdx.json\"",
+		"it is written where the build is handed over": "-o \"incoming/verify-tfg_${version}.spdx.json\"",
 		"the statement travels with the build":         "build.provenance.sigstore.json",
 	} {
 		if !strings.Contains(all, want) {

--- a/internal/guard/downloadorder_test.go
+++ b/internal/guard/downloadorder_test.go
@@ -1,0 +1,144 @@
+package guard
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The order of a release's downloads is decided by ONE thing, and it is not
+// anything this project controls at publish time.
+//
+// Measured on 2026-08-28 against a real draft release, four hypotheses tested
+// and three of them killed:
+//
+//   - upload order: no. Uploaded zzz, then mmm, then aaa, one at a time. The
+//     list came back aaa, mmm, zzz.
+//   - the asset id: no. The ids ran in upload order, the list did not.
+//   - the asset label: no. A file named aaa carrying the label zzz still sorted
+//     first, and a file named zzz labelled aaa sorted last.
+//   - the file name, alphabetically, IGNORING letter case: yes. A file called
+//     Zzz sorted after aaa, and probka_Windows sorted after probka_linux.
+//
+// So the only lever is the name, and that is what these guards are about. The
+// four files a person checks a download WITH have to sort after the things they
+// check, or they land in the middle of the programs - which is where they were:
+// SHA256SUMS.txt sorted above every archive, and the three statement files fell
+// between the window archives and the command line ones, because a dot sorts
+// before an underscore.
+
+// auxPrefix is what sign_release.py calls AUX_PREFIX, read from the script so
+// there is one written copy rather than two that drift apart.
+func auxPrefix(t *testing.T) string {
+	t.Helper()
+	found := regexp.MustCompile(`AUX_PREFIX = "([^"]+)"`).FindStringSubmatch(signingScript(t))
+	if found == nil {
+		t.Fatal("sign_release.py no longer names a prefix for the files a person " +
+			"checks a download with, so nothing keeps them out of the middle of the list")
+	}
+	return found[1]
+}
+
+// The prefix has to sort AFTER the archive names, or it is decoration.
+//
+// This asks about the property rather than about the spelling: any prefix that
+// sorts after both archive shapes passes, and the word "verify" is not required
+// by anything here. What is required is that it works.
+func TestTheFilesYouCheckADownloadWithSortToTheEnd(t *testing.T) {
+	prefix := auxPrefix(t)
+
+	// The two shapes an archive name takes today. Both are compared, because a
+	// prefix that beats one and loses to the other would split the list in a way
+	// that is harder to notice than the problem it replaced.
+	for _, archive := range []string{
+		"tfg_0.2.0_windows_amd64.zip",
+		"tfg-gui_0.2.0_windows_amd64.zip",
+	} {
+		if !sortsAfter(prefix, archive) {
+			t.Errorf("a file named %q sorts BEFORE %q, so it lands above or inside "+
+				"the list of programs instead of under it", prefix+"whatever", archive)
+		}
+	}
+
+	// And the whole list, sorted the way GitHub sorts it, has to put every
+	// program above every check file. This is the question the guard above asks
+	// in pieces, asked once in the shape a person actually sees.
+	names := []string{
+		"tfg-gui_0.2.0_windows_amd64.zip",
+		"tfg-gui_0.2.0_linux_amd64.tar.gz",
+		"tfg-gui_0.2.0_macos_arm64.tar.gz",
+		"tfg_0.2.0_windows_amd64.zip",
+		"tfg_0.2.0_linux_amd64.tar.gz",
+		"tfg_0.2.0_macos_arm64.tar.gz",
+		prefix + "SHA256SUMS.txt",
+		prefix + "tfg_0.2.0.spdx.json",
+		prefix + "tfg_0.2.0.provenance.sigstore.json",
+		prefix + "tfg_0.2.0.sbom.sigstore.json",
+	}
+	sort.Slice(names, func(i, j int) bool {
+		return strings.ToLower(names[i]) < strings.ToLower(names[j])
+	})
+	seenCheckFile := false
+	for _, name := range names {
+		if strings.HasPrefix(name, prefix) {
+			seenCheckFile = true
+			continue
+		}
+		if seenCheckFile {
+			t.Errorf("sorted the way GitHub sorts them, %q comes after a file a person "+
+				"checks downloads with, so the list is programs and checks interleaved: %v",
+				name, names)
+			break
+		}
+	}
+}
+
+// Every place that MAKES one of those four files has to use the prefix.
+//
+// Three different files create them - the build workflow makes the bill of
+// materials, the signing script writes the checksums and renames the build's
+// provenance, and the attestation workflow names the statement it publishes.
+// A prefix applied in two places out of three splits the list rather than
+// ordering it, and that is harder to spot than no prefix at all.
+func TestEveryFileYouCheckADownloadWithCarriesThePrefix(t *testing.T) {
+	prefix := auxPrefix(t)
+
+	// Asked as a NEGATIVE, and the first version of this guard is the reason.
+	// Asking whether the prefix appears anywhere in the file passed a mutation
+	// that took it off the one name being created, because these files mention
+	// the prefixed names elsewhere too. So this looks for the thing that must
+	// not be there: a bill of materials or a statement named without it.
+	bare := regexp.MustCompile(`["/]tfg_[^"'\s]*\.(spdx|sigstore)\.json`)
+
+	for _, where := range []struct{ what, text string }{
+		{"the build workflow, making the bill of materials",
+			withoutYamlComments(workflowText(t, "release.yml"))},
+		{"the signing script, writing the checksums and renaming the provenance",
+			signingScript(t)},
+		{"the attestation workflow, naming the statement it publishes",
+			withoutYamlComments(workflowText(t, "attest-release.yml"))},
+	} {
+		if !strings.Contains(where.text, prefix) {
+			t.Errorf("%s never uses the %q prefix, so the file it creates lands in the "+
+				"middle of the download list", where.what, prefix)
+		}
+		if found := bare.FindString(where.text); found != "" {
+			t.Errorf("%s names %s without the %q prefix, so that file sorts into the "+
+				"middle of the programs instead of under them", where.what, found, prefix)
+		}
+	}
+
+	// And the one that reads them back has to expect it, or it looks for a file
+	// that is not there and calls the release incomplete.
+	if !strings.Contains(withoutYamlComments(workflowText(t, "verify-release.yml")), prefix) {
+		t.Error("the published release check does not expect the prefix, so it will " +
+			"report the checksums file missing on a release that has it")
+	}
+}
+
+// sortsAfter answers the question GitHub answers: which name comes later,
+// ignoring letter case. Measured rather than assumed - see the note at the top.
+func sortsAfter(later, earlier string) bool {
+	return strings.ToLower(later) > strings.ToLower(earlier)
+}

--- a/internal/guard/signing_test.go
+++ b/internal/guard/signing_test.go
@@ -67,8 +67,12 @@ func TestTheReleaseHandsTheBuildOverInsteadOfPublishingIt(t *testing.T) {
 	if !strings.Contains(release, "sha256sum -- * > build.sha256") {
 		t.Error("the build no longer lists what it produced, so the statement below it names nothing")
 	}
-	if strings.Contains(release, "sha256sum -- * > SHA256SUMS.txt") {
-		t.Error("the build writes the checksums a user reads, and three of the files still change afterwards")
+	// The exact command, not the two halves separately. An earlier version of
+	// this asked whether the file appears anywhere AND whether that command
+	// appears anywhere, and went red on a release note that merely NAMES the
+	// checksums file - a sentence, not a build step.
+	if strings.Contains(release, "sha256sum -- * > verify-SHA256SUMS.txt") {
+		t.Error("the build writes the checksums a user reads, and five of the files still change afterwards")
 	}
 }
 
@@ -126,7 +130,7 @@ func TestTheAttestationWorkflowDoesNotClaimToHaveBuiltAnything(t *testing.T) {
 	for what, want := range map[string]string{
 		"it downloads what the release holds":                       "gh release download",
 		"it cross-checks the digest it was given":                   "CLAIMED",
-		"it checks the checksums describe the files they came with": "sha256sum -c SHA256SUMS.txt",
+		"it checks the checksums describe the files they came with": "sha256sum -c verify-SHA256SUMS.txt",
 		"it attests the document against those bytes":               "sbom-path",
 		"it publishes the statement as an asset":                    "gh release upload",
 	} {
@@ -165,7 +169,7 @@ func TestThePublishedReleaseIsCheckedTheWayAUserWould(t *testing.T) {
 		"it runs when a release is published":                         "types: [published]",
 		"it can be asked about an old tag":                            "workflow_dispatch",
 		"it downloads what a user downloads":                          "gh release download",
-		"it compares the checksums a user is told to compare":         "sha256sum -c SHA256SUMS.txt",
+		"it compares the checksums a user is told to compare":         "sha256sum -c verify-SHA256SUMS.txt",
 		"it runs the command the notes give":                          "gh attestation verify",
 		"it runs it the offline way too":                              "--bundle",
 		"it reads the certificate pin from the source":                "CodeSigningSHA256",

--- a/web/content/en/index.html
+++ b/web/content/en/index.html
@@ -174,7 +174,7 @@ tfg cleanup ./logs/manifest.json --yes</code></pre>
     <p class="note-title">The binaries are not signed</p>
     <p>
       Your system will warn you the first time you run one. The release notes say exactly what each
-      system shows and why. Every archive is listed in <code>SHA256SUMS.txt</code> on the release page,
+      system shows and why. Every archive is listed in <code>verify-SHA256SUMS.txt</code> on the release page,
       so you can check what you downloaded.
     </p>
   </div>

--- a/web/content/pl/index.html
+++ b/web/content/pl/index.html
@@ -174,7 +174,7 @@ tfg cleanup ./logs/manifest.json --yes</code></pre>
     <p class="note-title">Binarki nie są podpisane</p>
     <p>
       System ostrzeże przy pierwszym uruchomieniu. Nota wydania mówi dokładnie, co pokaże każdy system
-      i dlaczego. Każde archiwum jest wypisane w pliku <code>SHA256SUMS.txt</code> na stronie wydania,
+      i dlaczego. Każde archiwum jest wypisane w pliku <code>verify-SHA256SUMS.txt</code> na stronie wydania,
       więc możesz sprawdzić, co pobrałeś.
     </p>
   </div>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -290,7 +290,7 @@ tfg cleanup ./logs/manifest.json --yes</code></pre>
     <p class="note-title">The binaries are not signed</p>
     <p>
       Your system will warn you the first time you run one. The release notes say exactly what each
-      system shows and why. Every archive is listed in <code>SHA256SUMS.txt</code> on the release page,
+      system shows and why. Every archive is listed in <code>verify-SHA256SUMS.txt</code> on the release page,
       so you can check what you downloaded.
     </p>
   </div>

--- a/web/public/pl/index.html
+++ b/web/public/pl/index.html
@@ -290,7 +290,7 @@ tfg cleanup ./logs/manifest.json --yes</code></pre>
     <p class="note-title">Binarki nie są podpisane</p>
     <p>
       System ostrzeże przy pierwszym uruchomieniu. Nota wydania mówi dokładnie, co pokaże każdy system
-      i dlaczego. Każde archiwum jest wypisane w pliku <code>SHA256SUMS.txt</code> na stronie wydania,
+      i dlaczego. Każde archiwum jest wypisane w pliku <code>verify-SHA256SUMS.txt</code> na stronie wydania,
       więc możesz sprawdzić, co pobrałeś.
     </p>
   </div>


### PR DESCRIPTION
The four files a person uses to verify a download - the checksums and the three statements - now carry a `verify-` prefix, so they sit together at the **bottom** of the release page instead of above and between the programs.

## The order is decided by one thing, and it took measuring

GitHub orders a release's downloads **alphabetically by file name, ignoring letter case**, and nothing else moves them. Measured against a real draft release (created, measured, deleted). Three other hypotheses tested, all three wrong:

| hypothesis | verdict | evidence |
|---|---|---|
| upload order | **no** | uploaded `zzz`, `mmm`, `aaa` one at a time; list came back `aaa, mmm, zzz` |
| the asset id | **no** | ids ran in upload order, the list did not |
| the asset label | **no** | a file named `aaa` labelled `zzz` still sorted first |
| **the file name** | **yes** | the only one left |

## What was wrong

`SHA256SUMS.txt` sorted **above every program** - a capital S comes before t, and the sort would not have cared either way. The three `.json` files landed **between the window archives and the command line ones**, because a dot sorts before an underscore. Both are fixed by the same four renames.

| before | after |
|---|---|
| `SHA256SUMS.txt` | `verify-SHA256SUMS.txt` |
| `tfg_<v>.spdx.json` | `verify-tfg_<v>.spdx.json` |
| `tfg_<v>.provenance.sigstore.json` | `verify-tfg_<v>.provenance.sigstore.json` |
| `tfg_<v>.sbom.sigstore.json` | `verify-tfg_<v>.sbom.sigstore.json` |

## What this deliberately does NOT do

It does not put Windows above Linux above macOS. That order is **not alphabetical in any direction** and cannot be had without a sorting prefix on every archive, which would then live in the name of the file on someone's disk forever. I measured whether a capital letter could do it quietly - `Windows` before `linux` - and it cannot, because the sort ignores case. The owner said no to numeric prefixes, so systems stay alphabetical within each group.

`verify-` rather than a number because the word is true: these four are what you verify a download with. A number would sort exactly as well and say nothing about why it is there.

## Guards

Two, both proven by mutation:

- one asks the **property**, not the spelling - any prefix that sorts after both archive name shapes passes, and it also checks the whole list sorted the way GitHub sorts it;
- the other asks a **negative**, and the first version of it is the reason. Asking whether the prefix appears anywhere in a file passed a mutation that took it off the one name being created, because these files mention prefixed names elsewhere too. It now looks for an auxiliary file named *without* the prefix.

⚠️ Two existing guards went red on this change and both were right - one carried the old name, and one was a condition I had rewritten badly so that it matched the release note that merely *mentions* the checksums file. Both fixed.

## Breaking for anyone scripting the download

A script fetching `SHA256SUMS.txt` by name needs the new name from the next release on. `CHANGELOG.md` says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)