### PR TITLE
build(deps): bump go-i18n to 2.6.1, and name the module it brought with it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,22 @@ jobs:
         # saying which one moved - the notices file tracks the linked set and
         # dropped it, this list tracks the graph and keeps it.
         #
+        # Changed on 2026-08-31 by a Dependabot bump, and it is the exact case
+        # the second paragraph of .github/dependabot.yml warns about. Taking
+        # github.com/nicksnyder/go-i18n/v2 from 2.5.1 to 2.6.1 pulled a module
+        # nobody asked for into the graph: go.yaml.in/yaml/v3, which is the
+        # same yaml library as gopkg.in/yaml.v3 under the module path that
+        # project moved to. Both are in the graph now, because other modules
+        # still ask for the old path.
+        #
+        # Its licence was read from the pinned version rather than off a web
+        # page: LICENSE is MIT and Apache-2.0 together - the files ported from
+        # libyaml keep the MIT of the original C, the rest is Apache-2.0 with a
+        # NOTICE from Canonical - and both are one way compatible with GPL-3.0.
+        # It is in the GRAPH and linked into NEITHER binary, which is the
+        # distinction these two questions exist to keep apart, so it belongs
+        # here and not in the notices. The count went 67 to 68.
+        #
         # Changed on 2026-08-29 when AVIF arrived, and again on 2026-08-31
         # when JPEG XL did: github.com/gen2brain/gav1d and then
         # github.com/gen2brain/jxl, both picture encoders written in Go with
@@ -186,6 +202,7 @@ jobs:
             github.com/urfave/cli/v2 \
             github.com/xrash/smetrics \
             github.com/yuin/goldmark \
+            go.yaml.in/yaml/v3 \
             golang.org/x/crypto \
             golang.org/x/image \
             golang.org/x/mobile \

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -259,7 +259,7 @@ rymdport project.
 | `github.com/jsummers/gobmp` | v0.0.0-20230614200233-a9de23ed2e25 | MIT | (c) 2012-2015 Jason Summers |
 | `github.com/mattn/go-runewidth` | v0.0.24 | MIT | (c) 2016 Yasuhiro Matsumoto |
 | `github.com/nfnt/resize` | v0.0.0-20180221191011-83c6a9932646 | ISC | (c) 2012, Jan Schlicht |
-| `github.com/nicksnyder/go-i18n/v2` | v2.5.1 | MIT | (c) 2014 Nick Snyder https://github.com/nicksnyder |
+| `github.com/nicksnyder/go-i18n/v2` | v2.6.1 | MIT | (c) 2014 Nick Snyder https://github.com/nicksnyder |
 | `github.com/rymdport/portal` | v0.4.2 | Apache-2.0 | none stated, see below |
 | `github.com/srwiley/oksvg` | v0.0.0-20221011165216-be6e8873101c | BSD-3-Clause | (c) 2018, Steven R Wiley |
 | `github.com/srwiley/rasterx` | v0.0.0-20220730225603-2ab79fcdd4ef | BSD-3-Clause | (c) 2018, Steven R Wiley |

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/jsummers/gobmp v0.0.0-20230614200233-a9de23ed2e25 // indirect
 	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
-	github.com/nicksnyder/go-i18n/v2 v2.5.1
+	github.com/nicksnyder/go-i18n/v2 v2.6.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rymdport/portal v0.4.2 // indirect
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/a
 github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
-github.com/nicksnyder/go-i18n/v2 v2.5.1 h1:IxtPxYsR9Gp60cGXjfuR/llTqV8aYMsC472zD0D1vHk=
-github.com/nicksnyder/go-i18n/v2 v2.5.1/go.mod h1:DrhgsSDZxoAfvVrBVLXoxZn/pN5TXqaDbq7ju94viiQ=
+github.com/nicksnyder/go-i18n/v2 v2.6.1 h1:JDEJraFsQE17Dut9HFDHzCoAWGEQJom5s0TRd17NIEQ=
+github.com/nicksnyder/go-i18n/v2 v2.6.1/go.mod h1:Vee0/9RD3Quc/NmwEjzzD7VTZ+Ir7QbXocrkhOzmUKA=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -70,6 +70,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
 github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/image v0.43.0 h1:FLxcP4ec2350nTfOC8ysKtqYSIFbk/QGjw1ZHNP4tsY=
 golang.org/x/image v0.43.0/go.mod h1:rrpelvGFt+kLPAjPM4HeWPgrl0FtafueU//e5N0qk/Q=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=


### PR DESCRIPTION
Carries #24 on top of the current `main` and does the two things the bot cannot: **name the new module, and say what its licence is.** Once this lands, #24 can be closed - it is the same bump without these.

## The bump is not just a version

Taking `github.com/nicksnyder/go-i18n/v2` from 2.5.1 to 2.6.1 pulls **`go.yaml.in/yaml/v3` into the module graph**. It is the same yaml library as `gopkg.in/yaml.v3`, under the module path that project has moved to - and both are in the graph now, because other modules still ask for the old path.

This is exactly the case the second paragraph of `.github/dependabot.yml` warns about, and why a gomod pull request goes red until somebody looks. The red tick was the gate working, not a fault to route around.

## Licences, read from the pinned modules

- **`go.yaml.in/yaml/v3` v3.0.4** - MIT **and** Apache-2.0 together. The files ported from libyaml keep the MIT of the original C, the rest is Apache-2.0 with a `NOTICE` from Canonical. Both are one way compatible with GPL-3.0.
- **`github.com/nicksnyder/go-i18n/v2` v2.6.1** - still MIT, same copyright line as before.

Read out of the module cache at the pinned versions rather than off a web page, as immutable rule 11 asks.

## Graph or linked set

Measured rather than assumed: the new module is in the **graph** and linked into **neither** binary. So it goes in the list `ci.yml` pins and **not** in the notices, which track what actually ships. That distinction is the reason those are two separate questions.

The notices do move for `go-i18n` itself, which the window links - its version there now reads 2.6.1.

## D11

**Every pinned hash is unchanged**, so this is tidying rather than a major version question. `golden-values.py --check` reports 0 cases differing.

Checked the way `dependabot.yml` asks for: the full suite locally, green, not a green tick alone.