### PR TITLE
test+ci: give the race job a ceiling that matches the work, and stop it spending the budget on arithmetic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,7 +625,9 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       needs.touched.outputs.concurrency == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Raised from 30 on 2026-08-31, with the Go timeout below, and the reason is
+    # measured rather than "it went red". See that step for the numbers.
+    timeout-minutes: 45
     env:
       # The one thing in this project that needs a C toolchain. Linux runners
       # ship one, so this job carries the cost and the matrix above stays on
@@ -678,8 +680,27 @@ jobs:
         #
         # Race instrumentation costs five to twenty times the wall clock, and
         # this package renders twenty five screens and builds two binaries. The
-        # job's own thirty minutes is the ceiling that means something.
-        run: go test -tags "$(cat .github/build-tags)" ./... -count=1 -race -timeout 25m
+        # job's own ceiling is the one that means something, and this number
+        # stays below it so a slow run fails as a test rather than as a killed
+        # job with no output.
+        #
+        # Both were raised on 2026-08-31, from 25m under a 30m job. Not because
+        # a run went red, but because the margin had already gone and the reds
+        # were the symptom. Measured on the runner across four consecutive runs:
+        # 21m35s on main before JPEG XL, a timeout on the JPEG XL branch, 20m15s
+        # on main after it merged, and a timeout on the dependency bump. Two out
+        # of four, with no data race reported in any of them - a limit that
+        # decides on how busy the runner is tells you nothing about the code.
+        #
+        # 21m35s against 25m was never a margin, and that predates JPEG XL. What
+        # this package holds now is twenty four formats, two of them running a
+        # borrowed encoder, twenty five screens and two binaries, and the 25m
+        # was chosen when it held less. The cheap half of the answer is in
+        # internal/guard/jxlladder_test.go, which stopped spending the budget on
+        # arithmetic that finds no races - 102s to 54s under -race. This is the
+        # other half: the ceiling now matches the work rather than the work
+        # being shaved to fit a ceiling nobody remeasured.
+        run: go test -tags "$(cat .github/build-tags)" ./... -count=1 -race -timeout 40m
 
   coverage:
     name: coverage gate

--- a/internal/guard/jxlladder_test.go
+++ b/internal/guard/jxlladder_test.go
@@ -89,6 +89,15 @@ func TestJxlDrawsAPictureThatGrowsWithTheFileAndAlwaysFits(t *testing.T) {
 // tools/probes/jxlladder, which takes minutes. This is the version that runs
 // on every push and would still catch a codec raised underneath us, because a
 // new encoder moves every rung at once rather than one seed of one rung.
+//
+// Fewer seeds again under the race detector, and that needs saying rather than
+// hiding. This encoder is slow and the detector makes it slower: measured on
+// 2026-08-31, this one test took 80 s of the 102 s the four JPEG XL guards cost
+// under -race, and the whole guard package went past the 25 minute timeout the
+// race job allows. What that job exists to find is data races, and this test
+// walks the same single threaded arithmetic whatever it is given - so the
+// seeds it drops buy no race coverage at all. The full sweep still runs on all
+// three operating system jobs, which is where a wrong ceiling would show.
 func TestEveryJxlRungStillFitsInsideItsDeclaredCeiling(t *testing.T) {
 	rungs := jxl.Rungs()
 	if len(rungs) == 0 {
@@ -99,11 +108,17 @@ func TestEveryJxlRungStillFitsInsideItsDeclaredCeiling(t *testing.T) {
 	// asked for, and a longer label is more ink in the picture.
 	requested := []int64{int64(jxl.MinimumBytes), 1 << 14, 1 << 30}
 
+	seeds := uint64(8)
+	if raceEnabled {
+		seeds = 2
+		t.Logf("the race detector is on, so this sweeps %d seeds rather than 8 - it costs minutes here and finds no races either way", seeds)
+	}
+
 	for _, r := range rungs {
 		w, h, ceiling := int(r[0]), int(r[1]), r[2]
 		worst := int64(0)
 		var worstSeed uint64
-		for seed := uint64(0); seed < 8; seed++ {
+		for seed := uint64(0); seed < seeds; seed++ {
 			for _, want := range requested {
 				for _, withLabel := range []bool{true, false} {
 					label := ""


### PR DESCRIPTION
The race detector went red on the JPEG XL branch and again on the dependency bump, and both were **timeouts, not races** - the guard package passed the 25 minutes Go was given and died in whichever test the alarm caught. No data race was reported in either.

## The margin had already gone

Measured on the runner, four consecutive runs:

| run | race job |
|---|---|
| `main` before JPEG XL | **21m35s**, pass |
| JPEG XL branch | **timeout at 25m** |
| `main` after JPEG XL merged | **20m15s**, pass |
| dependency bump (#26) | **timeout at 25m** |

Two of four, against a stated 25m under a 30m job. **21m35s against 25m was never a margin, and that predates JPEG XL** - a limit that decides on how busy the runner happens to be is telling you about the runner, not the code.

## Two halves

**Cheap half - stop spending the budget on arithmetic.** `TestEveryJxlRungStillFitsInsideItsDeclaredCeiling` sweeps every rung across seeds and label lengths: 528 encodes, with an encoder several times slower than the AVIF one. Measured locally under `-race`, 80s of the 102s all four JPEG XL guards cost. It now sweeps **two seeds instead of eight when the detector is on**, and logs that it did.

That is not a gate quietly loosened: the race job exists to find data races, and this test walks the same single threaded arithmetic whatever it is handed, so the dropped seeds buy **no race coverage at all**. The full eight seed sweep still runs on all three operating system jobs, and the thorough 256 seed version is `tools/probes/jxlladder`. Measured after: **102s to 54s** under `-race`, off-race unchanged at eight seeds and 11.5s.

**Other half - the ceiling now matches the work** (owner's call). 25m under a 30m job becomes **40m under 45m**. The gap between the two is kept on purpose: Go's limit stays below the job's so a slow run fails as a test, with the list of what was still running, rather than as a killed job with no output - which is why that number was stated in the first place, on 2026-08-25.

The 25m was chosen when this package held less. It now holds twenty four formats, two of them running a borrowed encoder, twenty five screens and two binaries.

## Note

The job timeout guard counts that every job **has** a `timeout-minutes`, not what it says, so raising the value does not touch it - checked rather than assumed.