### PR TITLE
docs: a PowerShell script needs one more line, or a failed run reports success

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,21 @@ An invalid recipe writes **no files at all** and reports every problem at once,
 each naming the setting it is about. A run stopped with Ctrl+C still leaves a
 manifest, and never leaves a half written file behind.
 
+### A PowerShell script needs one more line
+
+PowerShell does not carry the exit code of a program out of a `.ps1` file. Run
+one with `-File` and the script answers `0` even when the tool inside refused
+the work, so a build that should be red goes green:
+
+```powershell
+tfg generate fixtures.yaml --out ./fixtures
+exit $LASTEXITCODE
+```
+
+That last line is the whole of it. This is how PowerShell behaves rather than
+anything about this tool, which returns the code from the table above either
+way. `cmd`, `bash` and `zsh` need nothing extra.
+
 ## ❓ Questions
 
 ### How is this different from `dd`, `fsutil` or `truncate`?

--- a/README.md
+++ b/README.md
@@ -377,8 +377,11 @@ tfg generate fixtures.yaml
 | `seed` | the number that makes a run repeatable. Same seed, same bytes |
 | `defaults.label` | write the self describing label inside each file. Default `true` |
 | `targets` | the list of things to produce. See below |
-| `output.dir` | where the files and the manifest go |
+| `output.dir` | where the files and the manifest go. A relative path is read from the directory you run in, not from the one the recipe sits in |
 | `output.manifest` | manifest file name. Default `manifest.json` |
+
+So a recipe kept in `recipes/` with `dir: out` writes into `out` next to you, not
+next to the recipe. Give an absolute path, or `--out`, when you want it fixed.
 
 ### Target keys
 


### PR DESCRIPTION
Found while building the pre-release ritual, and it is a fact about the people
who use this tool rather than about the tool.

## Measured

Both Windows PowerShell 5.1 and pwsh 7, exit code read from the process rather
than from `echo $?`:

| how it is run | exit code |
|---|---|
| `tfg --bad-flag` directly | **2** |
| the same call inside a `.ps1`, run with `-File` | **0** |
| the same `.ps1` ending with `exit $LASTEXITCODE` | **2** |

A `.ps1` does not inherit the exit code of the last program it ran. That is
PowerShell, not this tool - but `.ps1` is the ordinary wrapper on Windows, and
this tool is built to be wired into CI. Somebody following the exit code table
in the README would get a green build on a run that refused the work, which is
the silent failure this project forbids everywhere else.

## What changes

One subsection in the CI part of the README, with the line that fixes it. No
code changes - this cannot be fixed from our side, because the script's exit
code belongs to the shell.

`cmd`, `bash` and `zsh` need nothing extra, and the README says that too.

Recorded as `O172`, and the pre-release ritual already defends against it: every
`.ps1` it generates ends with `exit $LASTEXITCODE`, or it would be measuring
PowerShell instead of the program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
