### PR TITLE
site: the download button stops naming a version, and two stale sections go

### DIFF
--- a/internal/guard/site_test.go
+++ b/internal/guard/site_test.go
@@ -134,9 +134,16 @@ func factsFromTheProgram() site.Facts {
 		Presets:   ids,
 		Downloads: declaredDownloads(),
 		// Fixed on purpose. See the comment on the field.
-		Year:     2026,
-		Repo:     "https://github.com/donislawdev/TestingFilesGenerator",
-		Releases: "https://github.com/donislawdev/TestingFilesGenerator/releases/latest",
+		Year: 2026,
+		Repo: "https://github.com/donislawdev/TestingFilesGenerator",
+		// The list of releases rather than whichever one is newest, since
+		// 2026-09-03. "latest" skips a prerelease, so a page offering to
+		// download a version it had just named would hand over a different one
+		// the moment a release candidate existed - and nothing here compares
+		// the two, because this guard compares the site against the CODE. The
+		// button names no version now and leads to the list, which is true
+		// whatever is published.
+		Releases: "https://github.com/donislawdev/TestingFilesGenerator/releases",
 		Issues:   "https://github.com/donislawdev/TestingFilesGenerator/issues",
 		Support:  "https://donislawdev.com/support/",
 		Origin:   siteOrigin,

--- a/web/content/en/formats.html
+++ b/web/content/en/formats.html
@@ -76,15 +76,3 @@
         size: 4kb</code></pre>
 </section>
 
-<section class="section" id="next">
-  <h2>Formats that are not here yet</h2>
-  <p>
-    <code>7z</code>, <code>tiff</code>, <code>webp</code>, <code>mp3</code> and <code>mp4</code> are
-    planned and not built. They are absent from the list above rather than present and half working,
-    and asking for one is an error saying the format is unknown.
-  </p>
-  <p>
-    If you need one of them, or a format that is not on either list, the
-    <a href="{{ .Facts.Issues }}">issue tracker</a> is where that gets decided.
-  </p>
-</section>

--- a/web/content/en/index.html
+++ b/web/content/en/index.html
@@ -182,26 +182,3 @@ tfg cleanup ./logs/manifest.json --yes</code></pre>
   {{ template "downloadCta" . }}
 </section>
 
-<section class="section" id="scope">
-  <p class="eyebrow">Honest scope</p>
-  <h2>Where this is today</h2>
-  <p>
-    Version {{ .Facts.Version }}. A tool that oversells itself wastes your afternoon, so here is the
-    state of it.
-  </p>
-  <p>
-    <strong>Working end to end:</strong> {{ .Facts.FormatCount }} formats, recipes, presets, the desktop
-    window, <code>generate</code>, <code>validate</code>, <code>verify</code>, <code>cleanup</code>,
-    boundary sets, archive contents, size ranges, per format settings, manifests and every exit code.
-  </p>
-  <p>
-    <strong>Not there yet:</strong> five more formats are planned - <code>7z</code>, <code>tiff</code>,
-    <code>webp</code>, <code>mp3</code> and <code>mp4</code>. The preset catalogue has one entry so far.
-    Some recipe keys are recognised and refused with a message saying they are not built yet, rather
-    than being ignored quietly. The Linux downloads are unsigned.
-  </p>
-  <p>
-    Found a problem or want a format? The <a href="{{ .Facts.Issues }}">issue tracker</a> is open, and
-    so is the discussion about what gets built next.
-  </p>
-</section>

--- a/web/content/en/site.json
+++ b/web/content/en/site.json
@@ -54,7 +54,7 @@
     "schemaDescription": "A free and open source generator of test files for QA. It produces real files of twenty formats at any exact size and writes a manifest saying how the system under test should react to each one.",
     "ctaDownload": "Download",
     "ctaSource": "View the source",
-    "ctaNote": "Free and open source, GPL-3.0. Nothing to sign up for. The Windows and macOS downloads are signed and start without a warning. The Linux ones are unsigned.",
+    "ctaNote": "Free and open source, GPL-3.0. Nothing to sign up for. The Windows and macOS downloads are signed and start without a warning.",
     "colFormat": "Format",
     "colExtension": "Extension",
     "colSmallest": "Smallest file",

--- a/web/content/pl/formats.html
+++ b/web/content/pl/formats.html
@@ -77,15 +77,3 @@
         size: 4kb</code></pre>
 </section>
 
-<section class="section" id="next">
-  <h2>Formaty, których jeszcze nie ma</h2>
-  <p>
-    <code>7z</code>, <code>tiff</code>, <code>webp</code>, <code>mp3</code> i <code>mp4</code> są
-    zaplanowane i niezbudowane. Nie ma ich na liście wyżej, zamiast być obecne i działać połowicznie,
-    a poproszenie o któryś kończy się błędem mówiącym, że format jest nieznany.
-  </p>
-  <p>
-    Jeśli potrzebujesz któregoś z nich albo formatu, którego nie ma na żadnej z tych list,
-    <a href="{{ .Facts.Issues }}">zgłoszenia</a> są miejscem, gdzie się o tym decyduje.
-  </p>
-</section>

--- a/web/content/pl/index.html
+++ b/web/content/pl/index.html
@@ -182,27 +182,3 @@ tfg cleanup ./logs/manifest.json --yes</code></pre>
   {{ template "downloadCta" . }}
 </section>
 
-<section class="section" id="scope">
-  <p class="eyebrow">Uczciwy zakres</p>
-  <h2>Gdzie to dziś jest</h2>
-  <p>
-    Wersja {{ .Facts.Version }}. Narzędzie, które się przechwala, kosztuje popołudnie, więc oto stan
-    faktyczny.
-  </p>
-  <p>
-    <strong>Działa od początku do końca:</strong> {{ .Facts.FormatCount }} formatów, przepisy, presety,
-    okno, <code>generate</code>, <code>validate</code>, <code>verify</code>, <code>cleanup</code>,
-    zestawy graniczne, zawartość archiwów, zakresy rozmiarów, ustawienia formatów, manifesty i wszystkie
-    kody wyjścia.
-  </p>
-  <p>
-    <strong>Czego jeszcze nie ma:</strong> pięciu zaplanowanych formatów - <code>7z</code>,
-    <code>tiff</code>, <code>webp</code>, <code>mp3</code> i <code>mp4</code>. Katalog presetów ma na
-    razie jedną pozycję. Część kluczy przepisu jest rozpoznawana i odrzucana komunikatem, że nie ma ich
-    w tej wersji, zamiast być po cichu ignorowana. Pliki dla Linuksa nie są podpisane.
-  </p>
-  <p>
-    Znalazłeś błąd albo potrzebujesz formatu? <a href="{{ .Facts.Issues }}">Zgłoszenia</a> są otwarte,
-    tak samo jak dyskusja o tym, co powstanie następne.
-  </p>
-</section>

--- a/web/content/pl/site.json
+++ b/web/content/pl/site.json
@@ -54,7 +54,7 @@
     "schemaDescription": "Darmowy generator plików testowych dla QA o otwartym kodzie. Tworzy prawdziwe pliki w dwudziestu formatach o dokładnie zadanym rozmiarze i zapisuje manifest mówiący, jak testowany system ma na każdy z nich zareagować.",
     "ctaDownload": "Pobierz",
     "ctaSource": "Zobacz kod źródłowy",
-    "ctaNote": "Darmowe i otwarte, GPL-3.0. Bez zakładania konta. Pliki dla Windows i macOS są podpisane i uruchamiają się bez ostrzeżenia. Pliki dla Linuksa nie są podpisane.",
+    "ctaNote": "Darmowe i otwarte, GPL-3.0. Bez zakładania konta. Pliki dla Windows i macOS są podpisane i uruchamiają się bez ostrzeżenia.",
     "colFormat": "Format",
     "colExtension": "Rozszerzenie",
     "colSmallest": "Najmniejszy plik",

--- a/web/public/404.html
+++ b/web/public/404.html
@@ -63,7 +63,7 @@
       <p class="footer-head">Project</p>
       <ul class="plain">
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator">Source on GitHub</a></li>
-        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Downloads</a></li>
+        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases">Downloads</a></li>
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator/issues">Report a problem</a></li>
         <li><a href="https://donislawdev.com/support/">Support the project</a></li>
       </ul>

--- a/web/public/create-file-exact-size/index.html
+++ b/web/public/create-file-exact-size/index.html
@@ -193,10 +193,10 @@ truncate -s 10M test10mb.bin</code></pre>
     through that and four other jobs it is built for.
   </p>
   <div class="cta">
-  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Download 0.2.0</a>
+  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases">Download</a>
   <a class="button ghost" href="https://github.com/donislawdev/TestingFilesGenerator">View the source</a>
 </div>
-<p class="cta-note">Free and open source, GPL-3.0. Nothing to sign up for. The Windows and macOS downloads are signed and start without a warning. The Linux ones are unsigned.</p>
+<p class="cta-note">Free and open source, GPL-3.0. Nothing to sign up for. The Windows and macOS downloads are signed and start without a warning.</p>
 </section>
 
 <section class="section" id="which">
@@ -235,7 +235,7 @@ truncate -s 10M test10mb.bin</code></pre>
       <p class="footer-head">Project</p>
       <ul class="plain">
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator">Source on GitHub</a></li>
-        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Downloads</a></li>
+        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases">Downloads</a></li>
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator/issues">Report a problem</a></li>
         <li><a href="https://donislawdev.com/support/">Support the project</a></li>
       </ul>

--- a/web/public/docs/index.html
+++ b/web/public/docs/index.html
@@ -380,7 +380,7 @@ tfg preset eject size-boundaries &gt; my.yaml</code></pre>
       <p class="footer-head">Project</p>
       <ul class="plain">
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator">Source on GitHub</a></li>
-        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Downloads</a></li>
+        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases">Downloads</a></li>
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator/issues">Report a problem</a></li>
         <li><a href="https://donislawdev.com/support/">Support the project</a></li>
       </ul>

--- a/web/public/faq/index.html
+++ b/web/public/faq/index.html
@@ -234,10 +234,10 @@
     <a href="https://github.com/donislawdev/TestingFilesGenerator">README in the repository</a> is the full reference.
   </p>
   <div class="cta">
-  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Download 0.2.0</a>
+  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases">Download</a>
   <a class="button ghost" href="https://github.com/donislawdev/TestingFilesGenerator">View the source</a>
 </div>
-<p class="cta-note">Free and open source, GPL-3.0. Nothing to sign up for. The Windows and macOS downloads are signed and start without a warning. The Linux ones are unsigned.</p>
+<p class="cta-note">Free and open source, GPL-3.0. Nothing to sign up for. The Windows and macOS downloads are signed and start without a warning.</p>
 </section>
 
 </main>
@@ -252,7 +252,7 @@
       <p class="footer-head">Project</p>
       <ul class="plain">
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator">Source on GitHub</a></li>
-        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Downloads</a></li>
+        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases">Downloads</a></li>
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator/issues">Report a problem</a></li>
         <li><a href="https://donislawdev.com/support/">Support the project</a></li>
       </ul>

--- a/web/public/formats/index.html
+++ b/web/public/formats/index.html
@@ -656,18 +656,6 @@
         size: 4kb</code></pre>
 </section>
 
-<section class="section" id="next">
-  <h2>Formats that are not here yet</h2>
-  <p>
-    <code>7z</code>, <code>tiff</code>, <code>webp</code>, <code>mp3</code> and <code>mp4</code> are
-    planned and not built. They are absent from the list above rather than present and half working,
-    and asking for one is an error saying the format is unknown.
-  </p>
-  <p>
-    If you need one of them, or a format that is not on either list, the
-    <a href="https://github.com/donislawdev/TestingFilesGenerator/issues">issue tracker</a> is where that gets decided.
-  </p>
-</section>
 
 </main>
 
@@ -681,7 +669,7 @@
       <p class="footer-head">Project</p>
       <ul class="plain">
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator">Source on GitHub</a></li>
-        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Downloads</a></li>
+        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases">Downloads</a></li>
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator/issues">Report a problem</a></li>
         <li><a href="https://donislawdev.com/support/">Support the project</a></li>
       </ul>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -41,8 +41,8 @@
   "applicationSubCategory": "Software Testing",
   "operatingSystem": "Windows, macOS, Linux",
   "softwareVersion": "0.2.0",
-  "downloadUrl": "https:\/\/github.com\/donislawdev\/TestingFilesGenerator\/releases\/latest",
-  "installUrl": "https:\/\/github.com\/donislawdev\/TestingFilesGenerator\/releases\/latest",
+  "downloadUrl": "https:\/\/github.com\/donislawdev\/TestingFilesGenerator\/releases",
+  "installUrl": "https:\/\/github.com\/donislawdev\/TestingFilesGenerator\/releases",
   "softwareHelp": "https:\/\/github.com\/donislawdev\/TestingFilesGenerator",
   "license": "https://www.gnu.org/licenses/gpl-3.0.html",
   "isAccessibleForFree": true,
@@ -94,10 +94,10 @@
   </p>
 
   <div class="cta">
-  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Download 0.2.0</a>
+  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases">Download</a>
   <a class="button ghost" href="https://github.com/donislawdev/TestingFilesGenerator">View the source</a>
 </div>
-<p class="cta-note">Free and open source, GPL-3.0. Nothing to sign up for. The Windows and macOS downloads are signed and start without a warning. The Linux ones are unsigned.</p>
+<p class="cta-note">Free and open source, GPL-3.0. Nothing to sign up for. The Windows and macOS downloads are signed and start without a warning.</p>
   </div>
 
   <figure class="hero-shot">
@@ -296,35 +296,12 @@ tfg cleanup ./logs/manifest.json --yes</code></pre>
     </p>
   </div>
   <div class="cta">
-  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Download 0.2.0</a>
+  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases">Download</a>
   <a class="button ghost" href="https://github.com/donislawdev/TestingFilesGenerator">View the source</a>
 </div>
-<p class="cta-note">Free and open source, GPL-3.0. Nothing to sign up for. The Windows and macOS downloads are signed and start without a warning. The Linux ones are unsigned.</p>
+<p class="cta-note">Free and open source, GPL-3.0. Nothing to sign up for. The Windows and macOS downloads are signed and start without a warning.</p>
 </section>
 
-<section class="section" id="scope">
-  <p class="eyebrow">Honest scope</p>
-  <h2>Where this is today</h2>
-  <p>
-    Version 0.2.0. A tool that oversells itself wastes your afternoon, so here is the
-    state of it.
-  </p>
-  <p>
-    <strong>Working end to end:</strong> 24 formats, recipes, presets, the desktop
-    window, <code>generate</code>, <code>validate</code>, <code>verify</code>, <code>cleanup</code>,
-    boundary sets, archive contents, size ranges, per format settings, manifests and every exit code.
-  </p>
-  <p>
-    <strong>Not there yet:</strong> five more formats are planned - <code>7z</code>, <code>tiff</code>,
-    <code>webp</code>, <code>mp3</code> and <code>mp4</code>. The preset catalogue has one entry so far.
-    Some recipe keys are recognised and refused with a message saying they are not built yet, rather
-    than being ignored quietly. The Linux downloads are unsigned.
-  </p>
-  <p>
-    Found a problem or want a format? The <a href="https://github.com/donislawdev/TestingFilesGenerator/issues">issue tracker</a> is open, and
-    so is the discussion about what gets built next.
-  </p>
-</section>
 
 </main>
 
@@ -338,7 +315,7 @@ tfg cleanup ./logs/manifest.json --yes</code></pre>
       <p class="footer-head">Project</p>
       <ul class="plain">
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator">Source on GitHub</a></li>
-        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Downloads</a></li>
+        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases">Downloads</a></li>
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator/issues">Report a problem</a></li>
         <li><a href="https://donislawdev.com/support/">Support the project</a></li>
       </ul>

--- a/web/public/pl/dokumentacja/index.html
+++ b/web/public/pl/dokumentacja/index.html
@@ -380,7 +380,7 @@ tfg preset eject size-boundaries &gt; my.yaml</code></pre>
       <p class="footer-head">Projekt</p>
       <ul class="plain">
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator">Kod na GitHubie</a></li>
-        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Pobieranie</a></li>
+        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases">Pobieranie</a></li>
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator/issues">Zgłoś problem</a></li>
         <li><a href="https://donislawdev.com/support/">Wesprzyj projekt</a></li>
       </ul>

--- a/web/public/pl/faq/index.html
+++ b/web/public/pl/faq/index.html
@@ -235,10 +235,10 @@
     jaki potrafi zrobić. <a href="https://github.com/donislawdev/TestingFilesGenerator">README w repozytorium</a> jest pełną dokumentacją.
   </p>
   <div class="cta">
-  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Pobierz 0.2.0</a>
+  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases">Pobierz</a>
   <a class="button ghost" href="https://github.com/donislawdev/TestingFilesGenerator">Zobacz kod źródłowy</a>
 </div>
-<p class="cta-note">Darmowe i otwarte, GPL-3.0. Bez zakładania konta. Pliki dla Windows i macOS są podpisane i uruchamiają się bez ostrzeżenia. Pliki dla Linuksa nie są podpisane.</p>
+<p class="cta-note">Darmowe i otwarte, GPL-3.0. Bez zakładania konta. Pliki dla Windows i macOS są podpisane i uruchamiają się bez ostrzeżenia.</p>
 </section>
 
 </main>
@@ -253,7 +253,7 @@
       <p class="footer-head">Projekt</p>
       <ul class="plain">
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator">Kod na GitHubie</a></li>
-        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Pobieranie</a></li>
+        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases">Pobieranie</a></li>
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator/issues">Zgłoś problem</a></li>
         <li><a href="https://donislawdev.com/support/">Wesprzyj projekt</a></li>
       </ul>

--- a/web/public/pl/formaty/index.html
+++ b/web/public/pl/formaty/index.html
@@ -657,18 +657,6 @@
         size: 4kb</code></pre>
 </section>
 
-<section class="section" id="next">
-  <h2>Formaty, których jeszcze nie ma</h2>
-  <p>
-    <code>7z</code>, <code>tiff</code>, <code>webp</code>, <code>mp3</code> i <code>mp4</code> są
-    zaplanowane i niezbudowane. Nie ma ich na liście wyżej, zamiast być obecne i działać połowicznie,
-    a poproszenie o któryś kończy się błędem mówiącym, że format jest nieznany.
-  </p>
-  <p>
-    Jeśli potrzebujesz któregoś z nich albo formatu, którego nie ma na żadnej z tych list,
-    <a href="https://github.com/donislawdev/TestingFilesGenerator/issues">zgłoszenia</a> są miejscem, gdzie się o tym decyduje.
-  </p>
-</section>
 
 </main>
 
@@ -682,7 +670,7 @@
       <p class="footer-head">Projekt</p>
       <ul class="plain">
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator">Kod na GitHubie</a></li>
-        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Pobieranie</a></li>
+        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases">Pobieranie</a></li>
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator/issues">Zgłoś problem</a></li>
         <li><a href="https://donislawdev.com/support/">Wesprzyj projekt</a></li>
       </ul>

--- a/web/public/pl/index.html
+++ b/web/public/pl/index.html
@@ -41,8 +41,8 @@
   "applicationSubCategory": "Software Testing",
   "operatingSystem": "Windows, macOS, Linux",
   "softwareVersion": "0.2.0",
-  "downloadUrl": "https:\/\/github.com\/donislawdev\/TestingFilesGenerator\/releases\/latest",
-  "installUrl": "https:\/\/github.com\/donislawdev\/TestingFilesGenerator\/releases\/latest",
+  "downloadUrl": "https:\/\/github.com\/donislawdev\/TestingFilesGenerator\/releases",
+  "installUrl": "https:\/\/github.com\/donislawdev\/TestingFilesGenerator\/releases",
   "softwareHelp": "https:\/\/github.com\/donislawdev\/TestingFilesGenerator",
   "license": "https://www.gnu.org/licenses/gpl-3.0.html",
   "isAccessibleForFree": true,
@@ -94,10 +94,10 @@
   </p>
 
   <div class="cta">
-  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Pobierz 0.2.0</a>
+  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases">Pobierz</a>
   <a class="button ghost" href="https://github.com/donislawdev/TestingFilesGenerator">Zobacz kod źródłowy</a>
 </div>
-<p class="cta-note">Darmowe i otwarte, GPL-3.0. Bez zakładania konta. Pliki dla Windows i macOS są podpisane i uruchamiają się bez ostrzeżenia. Pliki dla Linuksa nie są podpisane.</p>
+<p class="cta-note">Darmowe i otwarte, GPL-3.0. Bez zakładania konta. Pliki dla Windows i macOS są podpisane i uruchamiają się bez ostrzeżenia.</p>
   </div>
 
   <figure class="hero-shot">
@@ -296,36 +296,12 @@ tfg cleanup ./logs/manifest.json --yes</code></pre>
     </p>
   </div>
   <div class="cta">
-  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Pobierz 0.2.0</a>
+  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases">Pobierz</a>
   <a class="button ghost" href="https://github.com/donislawdev/TestingFilesGenerator">Zobacz kod źródłowy</a>
 </div>
-<p class="cta-note">Darmowe i otwarte, GPL-3.0. Bez zakładania konta. Pliki dla Windows i macOS są podpisane i uruchamiają się bez ostrzeżenia. Pliki dla Linuksa nie są podpisane.</p>
+<p class="cta-note">Darmowe i otwarte, GPL-3.0. Bez zakładania konta. Pliki dla Windows i macOS są podpisane i uruchamiają się bez ostrzeżenia.</p>
 </section>
 
-<section class="section" id="scope">
-  <p class="eyebrow">Uczciwy zakres</p>
-  <h2>Gdzie to dziś jest</h2>
-  <p>
-    Wersja 0.2.0. Narzędzie, które się przechwala, kosztuje popołudnie, więc oto stan
-    faktyczny.
-  </p>
-  <p>
-    <strong>Działa od początku do końca:</strong> 24 formatów, przepisy, presety,
-    okno, <code>generate</code>, <code>validate</code>, <code>verify</code>, <code>cleanup</code>,
-    zestawy graniczne, zawartość archiwów, zakresy rozmiarów, ustawienia formatów, manifesty i wszystkie
-    kody wyjścia.
-  </p>
-  <p>
-    <strong>Czego jeszcze nie ma:</strong> pięciu zaplanowanych formatów - <code>7z</code>,
-    <code>tiff</code>, <code>webp</code>, <code>mp3</code> i <code>mp4</code>. Katalog presetów ma na
-    razie jedną pozycję. Część kluczy przepisu jest rozpoznawana i odrzucana komunikatem, że nie ma ich
-    w tej wersji, zamiast być po cichu ignorowana. Pliki dla Linuksa nie są podpisane.
-  </p>
-  <p>
-    Znalazłeś błąd albo potrzebujesz formatu? <a href="https://github.com/donislawdev/TestingFilesGenerator/issues">Zgłoszenia</a> są otwarte,
-    tak samo jak dyskusja o tym, co powstanie następne.
-  </p>
-</section>
 
 </main>
 
@@ -339,7 +315,7 @@ tfg cleanup ./logs/manifest.json --yes</code></pre>
       <p class="footer-head">Projekt</p>
       <ul class="plain">
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator">Kod na GitHubie</a></li>
-        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Pobieranie</a></li>
+        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases">Pobieranie</a></li>
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator/issues">Zgłoś problem</a></li>
         <li><a href="https://donislawdev.com/support/">Wesprzyj projekt</a></li>
       </ul>

--- a/web/public/pl/plik-o-zadanym-rozmiarze/index.html
+++ b/web/public/pl/plik-o-zadanym-rozmiarze/index.html
@@ -195,10 +195,10 @@ truncate -s 10M test10mb.bin</code></pre>
     i przez cztery inne zadania, pod które to powstało.
   </p>
   <div class="cta">
-  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Pobierz 0.2.0</a>
+  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases">Pobierz</a>
   <a class="button ghost" href="https://github.com/donislawdev/TestingFilesGenerator">Zobacz kod źródłowy</a>
 </div>
-<p class="cta-note">Darmowe i otwarte, GPL-3.0. Bez zakładania konta. Pliki dla Windows i macOS są podpisane i uruchamiają się bez ostrzeżenia. Pliki dla Linuksa nie są podpisane.</p>
+<p class="cta-note">Darmowe i otwarte, GPL-3.0. Bez zakładania konta. Pliki dla Windows i macOS są podpisane i uruchamiają się bez ostrzeżenia.</p>
 </section>
 
 <section class="section" id="which">
@@ -237,7 +237,7 @@ truncate -s 10M test10mb.bin</code></pre>
       <p class="footer-head">Projekt</p>
       <ul class="plain">
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator">Kod na GitHubie</a></li>
-        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Pobieranie</a></li>
+        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases">Pobieranie</a></li>
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator/issues">Zgłoś problem</a></li>
         <li><a href="https://donislawdev.com/support/">Wesprzyj projekt</a></li>
       </ul>

--- a/web/public/pl/zastosowania/index.html
+++ b/web/public/pl/zastosowania/index.html
@@ -188,10 +188,10 @@ tfg generate --format xlsx --size 2mb --set rows=400 --set columns=6 --out ./she
     środowisku firmowym, gdzie generator w przeglądarce nie wchodzi w grę.
   </p>
   <div class="cta">
-  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Pobierz 0.2.0</a>
+  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases">Pobierz</a>
   <a class="button ghost" href="https://github.com/donislawdev/TestingFilesGenerator">Zobacz kod źródłowy</a>
 </div>
-<p class="cta-note">Darmowe i otwarte, GPL-3.0. Bez zakładania konta. Pliki dla Windows i macOS są podpisane i uruchamiają się bez ostrzeżenia. Pliki dla Linuksa nie są podpisane.</p>
+<p class="cta-note">Darmowe i otwarte, GPL-3.0. Bez zakładania konta. Pliki dla Windows i macOS są podpisane i uruchamiają się bez ostrzeżenia.</p>
 </section>
 
 </main>
@@ -206,7 +206,7 @@ tfg generate --format xlsx --size 2mb --set rows=400 --set columns=6 --out ./she
       <p class="footer-head">Projekt</p>
       <ul class="plain">
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator">Kod na GitHubie</a></li>
-        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Pobieranie</a></li>
+        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases">Pobieranie</a></li>
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator/issues">Zgłoś problem</a></li>
         <li><a href="https://donislawdev.com/support/">Wesprzyj projekt</a></li>
       </ul>

--- a/web/public/use-cases/index.html
+++ b/web/public/use-cases/index.html
@@ -189,10 +189,10 @@ tfg generate --format xlsx --size 2mb --set rows=400 --set columns=6 --out ./she
     a closed corporate environment where a browser based generator is not an option.
   </p>
   <div class="cta">
-  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Download 0.2.0</a>
+  <a class="button primary" href="https://github.com/donislawdev/TestingFilesGenerator/releases">Download</a>
   <a class="button ghost" href="https://github.com/donislawdev/TestingFilesGenerator">View the source</a>
 </div>
-<p class="cta-note">Free and open source, GPL-3.0. Nothing to sign up for. The Windows and macOS downloads are signed and start without a warning. The Linux ones are unsigned.</p>
+<p class="cta-note">Free and open source, GPL-3.0. Nothing to sign up for. The Windows and macOS downloads are signed and start without a warning.</p>
 </section>
 
 </main>
@@ -207,7 +207,7 @@ tfg generate --format xlsx --size 2mb --set rows=400 --set columns=6 --out ./she
       <p class="footer-head">Project</p>
       <ul class="plain">
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator">Source on GitHub</a></li>
-        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases/latest">Downloads</a></li>
+        <li><a href="https://github.com/donislawdev/TestingFilesGenerator/releases">Downloads</a></li>
         <li><a href="https://github.com/donislawdev/TestingFilesGenerator/issues">Report a problem</a></li>
         <li><a href="https://donislawdev.com/support/">Support the project</a></li>
       </ul>

--- a/web/templates/partials.html
+++ b/web/templates/partials.html
@@ -197,7 +197,7 @@
 
 {{- define "downloadCta" -}}
 <div class="cta">
-  <a class="button primary" href="{{ .Facts.Releases }}">{{ .Word "ctaDownload" }} {{ .Facts.Version }}</a>
+  <a class="button primary" href="{{ .Facts.Releases }}">{{ .Word "ctaDownload" }}</a>
   <a class="button ghost" href="{{ .Facts.Repo }}">{{ .Word "ctaSource" }}</a>
 </div>
 <p class="cta-note">{{ .Word "ctaNote" }}</p>


### PR DESCRIPTION
The download button said **"Download 0.2.0"** and led to `/releases/latest`.
Those two halves cannot both stay true.

`latest` skips a prerelease by design, so the moment a release candidate exists
the page names one version and hands over another. Nothing here would catch it:
`TestTheSiteSaysWhatTheToolSays` compares the site against the **code**, so both
halves would agree with each other while being wrong about what a visitor
actually receives.

**The button now reads `Download` and leads to the list of releases.** A list is
true whatever is published, so the page makes no promise it can break. It also
removes the reason to tag a release from a branch just to keep the site honest.

The `Releases` fact moved with it, so the footer link and the JSON-LD
`downloadUrl` point at the list too, rather than at two different places.

## Two of the removals were carrying live falsehoods

"Where this is today" on the front page and "Formats that are not here yet" on
the formats page **both listed `tiff` and `webp` as planned and not built**.
Both shipped on 2026-08-29.

The site guard could not see it. It renders the numbers a program can be asked
for, and no code claims a list of formats that do not exist - so that sentence
was prose nothing was checking. Deleting the sections removed the claim rather
than dating it.

The sentence "The Linux ones are unsigned" is gone from the call to action in
both languages.

## How the cuts were made

Everything was edited in the **sources** under `web/content` and
`web/templates`, and `web/public` was regenerated from them - the published
pages are generated, so editing those directly would be undone by the next run.

Sections were cut by content rather than by line numbers, and the seams are
checked: no orphaned markup, nothing linked to `#scope` or `#next`,
`FormatCount` is still used in six other places, and no `releases/latest`
remains anywhere on the site.

Full suite and `preflight --quick` green locally, 12 of 12 including the three
CI-only checks.

## Not in this change

Two version references remain on the site and are untouched: the footer brand
line and the JSON-LD `softwareVersion`. Neither is a promise about what a
download gives you, so neither breaks the way the button did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
