### PR TITLE
perf: an archive names its directories once and encrypts into one buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,17 @@ because it turns other people's test suites red.
   in front of the picture, so it has to know how large the picture is before it
   starts.
 
+- **A password protected archive allocates once per entry instead of once per
+  block written.** Producing a 128 MB locked `.zip` used to make the collector
+  run 48 times. It runs 6. The files are identical and the wall clock barely
+  moves, so this is headroom rather than a speed-up you will notice.
+
+- **Nesting files deep inside an archive costs almost nothing to name.** The
+  directory chain in front of every entry was rebuilt for each one, though it
+  depends only on the depth. At the deepest setting with 10 000 entries that was
+  82 ms of naming, and it is now close to nothing. Archives left flat, which is
+  the default, never paid it either way.
+
 - **`verify` and `cleanup` read the files over several threads, so checking a
   large run is several times faster.** Nothing about what they report changes -
   the same differences, in the same order, with the same exit codes.

--- a/internal/format/archive/layout.go
+++ b/internal/format/archive/layout.go
@@ -1,7 +1,6 @@
 package archive
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -59,18 +58,22 @@ const (
 	// format rather than trusting this paragraph.
 	maxDepth = 50
 
-	// dirSegment numbers the levels so a path reads as what it is. Two digits
-	// because maxDepth is two digits, and a fixed width so every segment is
-	// the same size and the arithmetic above stays a multiplication.
-	dirSegment = "d%02d/"
-
-	// dirSegmentBytes is what one segment comes to once rendered - "d00/" is
-	// four bytes where the format string above is six. Written out rather than
-	// taken as len(dirSegment), which is the bug the depth guard caught the
-	// first time it ran: the arithmetic said every path was 2 bytes per level
-	// longer than it is, which would have understated the ceiling rather than
-	// overstating it, so nothing would have failed until somebody widened the
-	// segment. A guard compares this against a really rendered path.
+	// A level is written as "d00/": the letter, the number padded to two
+	// digits because maxDepth is two digits, and the separator. A fixed width
+	// is what keeps the arithmetic above a multiplication rather than a walk.
+	//
+	// It used to be a "d%02d/" format string rendered through fmt, and that
+	// cost more than everything else about naming an entry put together -
+	// measured 2026-09-06 at depth 50 over 10 000 entries, 82.2 ms against
+	// 30.6 ms once the verb went. Prefix writes the four bytes out by hand.
+	//
+	// dirSegmentBytes is what one level comes to. It was written out rather
+	// than taken as the length of that format string, which is the bug the
+	// depth guard caught the first time it ran: six bytes rather than four
+	// said every path was 2 bytes per level longer than it is, which
+	// understates the ceiling instead of overstating it, so nothing would have
+	// failed until somebody widened the segment. A guard still compares this
+	// against a really rendered path.
 	dirSegmentBytes = 4
 )
 
@@ -87,15 +90,38 @@ type Layout struct {
 // The empty name gives the directory chain itself with its trailing slash,
 // which is what both containers want a directory entry to be called.
 func (l Layout) Path(name string) string {
+	return l.Prefix() + name
+}
+
+// Prefix is the directory chain on its own, with nothing on the end.
+//
+// It depends on Depth and on nothing else, so a caller naming thousands of
+// entries works it out once rather than once per entry. Measured 2026-09-06 at
+// depth 50 over 10 000 entries: a median of 82.2 ms rebuilding it every time
+// against 1.08 ms building it once, ranges disjoint.
+//
+// The default depth is zero and a flat archive spends nothing here either way,
+// so this is a ceiling rather than a typical run - which is worth saying,
+// because the number above reads like a saving every user gets.
+//
+// Rendered by hand rather than through fmt: the format verb is what made the
+// old version expensive, and a two digit number with a floor of two is small
+// enough to write out. "d%02d/" pads to two and lets a third digit through,
+// which is what the branch below does.
+func (l Layout) Prefix() string {
 	if l.Depth <= 0 {
-		return name
+		return ""
 	}
 	var b strings.Builder
-	b.Grow(l.Depth*len(dirSegment) + len(name))
+	b.Grow(l.Depth * dirSegmentBytes)
 	for i := 0; i < l.Depth; i++ {
-		fmt.Fprintf(&b, dirSegment, i)
+		b.WriteByte('d')
+		if i < 10 {
+			b.WriteByte('0')
+		}
+		b.WriteString(strconv.Itoa(i))
+		b.WriteByte('/')
 	}
-	b.WriteString(name)
 	return b.String()
 }
 

--- a/internal/format/archive/lock.go
+++ b/internal/format/archive/lock.go
@@ -274,6 +274,8 @@ type entryWriter struct {
 	out io.Writer
 	ctr *counter
 	mac hash
+	// buf is reused across writes. See Write.
+	buf []byte
 }
 
 // hash is the part of hash.Hash this uses. Named so the field above reads as
@@ -284,7 +286,14 @@ type hash interface {
 }
 
 func (e *entryWriter) Write(p []byte) (int, error) {
-	out := make([]byte, len(p))
+	// A scratch buffer that lives as long as the entry rather than one per
+	// call. It cannot be done in place: p belongs to the caller, and the zip
+	// writer hands the same slice on elsewhere, so scrambling it here would
+	// corrupt what somebody else is about to read.
+	if cap(e.buf) < len(p) {
+		e.buf = make([]byte, len(p))
+	}
+	out := e.buf[:len(p)]
 	e.ctr.xor(out, p)
 	if _, err := e.mac.Write(out); err != nil {
 		return 0, err

--- a/internal/format/archive/zipcrypto.go
+++ b/internal/format/archive/zipcrypto.go
@@ -82,6 +82,8 @@ func (c *pkware) encrypt(p byte) byte {
 type zipCryptoWriter struct {
 	out io.Writer
 	c   *pkware
+	// buf is reused across writes. See Write.
+	buf []byte
 }
 
 // newZipCryptoWriter starts an entry, writing the twelve byte header before
@@ -111,7 +113,12 @@ func (l Lock) newZipCryptoWriter(w io.Writer, seed uint64, index int, crc uint32
 }
 
 func (z *zipCryptoWriter) Write(p []byte) (int, error) {
-	out := make([]byte, len(p))
+	// Reused across writes, and not done in place for the reason written out
+	// on entryWriter.Write: p belongs to the caller.
+	if cap(z.buf) < len(p) {
+		z.buf = make([]byte, len(p))
+	}
+	out := z.buf[:len(p)]
 	for i := range p {
 		out[i] = z.c.encrypt(p[i])
 	}

--- a/internal/format/targz/targz.go
+++ b/internal/format/targz/targz.go
@@ -252,6 +252,9 @@ func (generator) Plan(r format.Request) (format.Plan, error) {
 // seed of a member does not move when a group above it changes count. That is
 // untouchable rule 2 applied one level down.
 func planChildren(r format.Request, groups []format.Content, layout archive.Layout) ([]child, error) {
+	// The directory chain depends only on the depth, so it is built once here
+	// rather than once per entry.
+	prefix := layout.Prefix()
 	var out []child
 	index := 0
 	// Numbering runs per format rather than per group, so two groups of the
@@ -273,7 +276,7 @@ func planChildren(r format.Request, groups []format.Content, layout archive.Layo
 			}
 			numbered[g.Format]++
 			out = append(out, child{
-				name: layout.Path(fmt.Sprintf("%s_%04d%s", g.Format, numbered[g.Format], desc.Extension)),
+				name: prefix + fmt.Sprintf("%s_%04d%s", g.Format, numbered[g.Format], desc.Extension),
 				desc: desc,
 				plan: cp,
 			})

--- a/internal/format/zip/children.go
+++ b/internal/format/zip/children.go
@@ -24,6 +24,10 @@ import (
 // seed of a member does not move when a group above it changes count. That is
 // untouchable rule 2 applied one level down.
 func planChildren(r format.Request, groups []format.Content, layout archive.Layout) ([]child, error) {
+	// The directory chain depends only on the depth, so it is built once here
+	// rather than once per entry.
+	prefix := layout.Prefix()
+
 	// Sized up front, because the total is known before the walk starts: it is
 	// what the groups add up to. Growing by append instead reallocates and
 	// copies the whole slice fourteen times on the way to ten thousand entries,
@@ -54,7 +58,7 @@ func planChildren(r format.Request, groups []format.Content, layout archive.Layo
 			}
 			numbered[g.Format]++
 			out = append(out, child{
-				name: layout.Path(fmt.Sprintf("%s_%04d%s", g.Format, numbered[g.Format], desc.Extension)),
+				name: prefix + fmt.Sprintf("%s_%04d%s", g.Format, numbered[g.Format], desc.Extension),
 				desc: desc,
 				plan: cp,
 			})


### PR DESCRIPTION
Sixth chunk of the 2026-09-05 performance report: `P9` and `P10`. **Neither moves a byte.**

> ⚠️ **Stacked on #58** (`perf/plan-without-encoding`), so the base is that branch rather than `main`. It has to be: `docs/`, `tools/` and `CLAUDE.md` are single repositories with no branches, so a branch cut from `main` fails `TestEveryGuardIsEitherProvenByMutationOrListedAsNotProven` and `TestEveryGuardCitedInTheSummaryIsJustifiedInRegression` for guards that exist only on #58. Merge #58 first and this collapses to its own three commits.

## `P9` - the directory chain, built once

`Layout.Path` rebuilt the chain for every entry, through a `fmt` format verb, though it depends only on `Depth`. `Prefix()` builds it, and the two hot callers hoist it out of their loops.

| variant | median, depth 50, 10 000 entries |
|---|---|
| before (`fmt.Fprintf` per entry) | **82.2 ms** |
| the verb removed, still per entry | **30.6 ms** |
| prefix built once (what the code does) | **~0 ms** |

So **more than half of it was the format verb**, which the report did not separate from the loop.

⚠️ `defaultDepth` is 0, and at zero the prefix is empty - a flat archive never paid any of this. **This is the ceiling of a setting, not a run anybody has.**

## `P10` - one buffer per entry, not per write

Both locked-entry writers allocated a fresh `make([]byte, len(p))` on every `Write`. At 128 MB in 32 kB blocks that is roughly four thousand allocations.

🔴 **It cannot be done in place**, and that is the only reason a buffer exists at all: `p` belongs to the caller and the zip writer passes the same slice on, so encrypting it where it lies would corrupt what someone else is about to read. Written next to both writers.

**Nobody had measured this** - `entryWriter` is unexported, so a probe outside the package cannot reach it - and the clock does not settle it either: the processor-time ranges **overlap**. The collector count does, and it is deterministic:

```
GODEBUG=gctrace=1, 128 MB locked zip
aes-256     48 collections -> 6
zipcrypto   48 collections -> 7
```

System time fell visibly too (203 → 78 ms, 234 → 141 ms) and the wall clock slightly (585 → 570, 630 → 597). **I do not claim a processor-time figure.**

## No new guard, on purpose

Both are already guarded: `archivedepth_test.go` compares path length against the `LongestPath` arithmetic, and `archivelock_test.go` checks exact size, a real archiver opening it, and determinism. Adding a fourth defence beside three is the shape this project has removed seven times.

Instead, **three mutations prove those guards catch the broken version**: lost zero-padding in a level name, and - for both writers - the buffer handed on at full length instead of the length written. All caught.

⚠️ One mutation pattern went stale from this change (it quoted the `layout.Path(...)` call that was rewritten). `staleness.py` caught it; retargeted and re-proven.

## Verification

- full `go test -tags "$(cat .github/build-tags)" ./...` - green, 83 packages
- `python tools/preflight.py --quick` - all 12 checks pass
- `try-named.py` on both guards - 5 mutations, all caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)