### PR TITLE
perf: a recipe is parsed once instead of twice, and the verdict on P4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,20 @@ because it turns other people's test suites red.
   in front of the picture, so it has to know how large the picture is before it
   starts.
 
+- **A recipe is parsed once instead of twice.** Reading a recipe checked it
+  for a stray second document and then handed the whole file to the decoder,
+  which parsed it again from scratch. The decoder now works from what was
+  already parsed.
+
+  Measured on the largest recipe the size limit allows, 900 kB and 20 000
+  targets: `validate` went from 839 ms to 754 ms. An ordinary recipe of a few
+  kilobytes was already instant. Where it shows is the batch screen, which
+  re-reads the recipe on every keystroke.
+
+  **Every refusal says exactly what it said before** - 48 malformed recipes
+  through two commands, compared character for character including the exit
+  code.
+
 - **A password protected archive allocates once per entry instead of once per
   block written.** Producing a 128 MB locked `.zip` used to make the collector
   run 48 times. It runs 6. The files are identical and the wall clock barely

--- a/internal/recipe/recipe.go
+++ b/internal/recipe/recipe.go
@@ -8,6 +8,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/ast"
 )
 
 // SchemaVersion is the recipe schema this build understands. It is versioned
@@ -194,14 +195,15 @@ func Parse(src []byte, name string) (*Recipe, error) {
 	// One file is one recipe. Everything after a document separator would be
 	// dropped by the decoder, which means somebody gets half the fixtures they
 	// asked for and a run that says it went fine.
-	if _, err := oneDocument(src, name); err != nil {
+	doc, err := oneDocument(src, name)
+	if err != nil {
 		return nil, err
 	}
 
 	// Strict decoding turns an unknown key into an error. A typo in
 	// "siez: 10mb" accepted in silence gives a file of the default size and an
 	// hour spent wondering why the test passes when it should not.
-	if err := decodeStrict(src, &raw); err != nil {
+	if err := decodeStrict(doc, &raw); err != nil {
 		return nil, &SyntaxError{Name: name, Detail: strings.TrimRight(err.Error(), "\n")}
 	}
 
@@ -226,7 +228,7 @@ func Parse(src []byte, name string) (*Recipe, error) {
 // Scoped to this one call rather than to the whole of Parse. A crash in our own
 // validation should still arrive as a crash, not be quietly relabelled as a
 // problem with the user's file.
-func decodeStrict(src []byte, raw *rawRecipe) (err error) {
+func decodeStrict(f *ast.File, raw *rawRecipe) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			// The panic value itself says "invalid memory address", which tells
@@ -235,7 +237,41 @@ func decodeStrict(src []byte, raw *rawRecipe) (err error) {
 			err = fmt.Errorf("this file could not be read as YAML. Look for a tag or anchor marker such as ! or & with nothing after it")
 		}
 	}()
-	return yaml.UnmarshalWithOptions(src, raw, yaml.Strict())
+	// Decoded from the document the one-document check already parsed, rather
+	// than from the bytes again. Handing the decoder the source makes it parse
+	// the whole file a second time, and this file is read once per run and once
+	// per keystroke on the batch screen.
+	//
+	// Measured 2026-09-06 on the largest recipe the size limit allows, 900 kB
+	// and 20 000 targets: the second parse is 107 ms of an 841 ms validate,
+	// ranges disjoint.
+	//
+	// The document count still comes from the parsed tree rather than from
+	// counting separators in the token stream, and that is deliberate: a
+	// comment before a leading "---" is a document with no body, and counting
+	// raw separators refused files that are ordinary YAML house style. That was
+	// a real defect once and TestOneRecipeIsAcceptedWhateverSeparatorsSurroundIt
+	// exists because of it.
+	body := recipeBody(f)
+	if body == nil {
+		// Nothing but comments or separators. The validator below says what is
+		// missing, in its own words, rather than the decoder complaining about
+		// an empty document.
+		return nil
+	}
+	return yaml.NodeToValue(body, raw, yaml.Strict())
+}
+
+// recipeBody is the document that holds the recipe, or nil when the file holds
+// no document with a body. It picks the same document recipesIn counts.
+func recipeBody(f *ast.File) ast.Node {
+	for _, d := range f.Docs {
+		if d.Body == nil || d.Body.Type() == ast.CommentType {
+			continue
+		}
+		return d.Body
+	}
+	return nil
 }
 
 // rawRecipe carries every key the recipe document describes, including the


### PR DESCRIPTION
Seventh chunk: `P5` done, and `P4` closed with a measurement instead of code. **These were the last two open items in the report.**

> ⚠️ **Stacked on #59** for the same reason it is stacked on #58 - `docs/`, `tools/` and `CLAUDE.md` have no branches. Merge #58 and #59 first.

## `P5` - and deliberately *not* the fix the report asked for

Reading a recipe walked the document three times: the lexer for flow depth, a full parse to check for a stray second document, and the decoder, which parsed the whole file **again**.

🔴 **The report's fix would have reintroduced a defect this project already fixed.** It proposed dropping the parse and counting documents from the token stream. But `recipesIn` counts documents **with a body**, and a comment before a leading `---` is a document without one. Counting raw separators refused files written in ordinary YAML house style - which is exactly why `TestOneRecipeIsAcceptedWhateverSeparatorsSurroundIt` exists, with a comment describing that bug.

So the parse stays and **the decoder's** one goes: it now works from the tree already built. The document-counting semantics are untouched.

| | |
|---|---|
| report's claim | 36% of the read |
| the discarded parse, measured | **13%** (107 ms of 841 ms) |
| what the change delivers | **10%** (839 → 754 ms), ranges disjoint |

Measured on the largest recipe the size limit allows: 900 kB, 20 000 targets, nine repetitions interleaved. A few-kilobyte recipe was already instant; where this shows is the batch screen, which re-reads on every keystroke.

### The evidence a green suite could not give

This moves the **words of a refusal**, not the bytes of a file, and no byte guard can see that. Your condition was the corpus before and after, so `tools/probes/refusalcorpus.py` now exists: 48 malformed and awkward recipes (syntax errors, unknown keys, two BOMs, tabs, unclosed brackets, tags with nothing after them, seven separator layouts) through `validate` and `generate --dry-run`, comparing stdout, stderr **and the exit code**.

**96 of 96 identical.** Plus five fuzz targets at 20s each, clean.

### Two stale mutation entries, one of them mine

The existing strictness entry quoted the call that was replaced, so it reported `SKIP` and had stopped proving anything. And the entry I added beside it duplicated it while naming a guard about *declared* keys rather than typos - it came back `NOT CAUGHT`, which was a statement about my entry, not about the code. Duplicate removed, original repaired, three mutations caught.

## `P4` - true as a proportion, below the threshold in effect. No code.

| batches | whole settle | Hash | Hash share |
|---|---|---|---|
| **20** (the report's own case) | **2.50 ms** | 0.98 | ~39% |
| 100 | 11.93 ms | 4.52 | 38% |
| 200 | 24.53 ms | 9.36 | 38% |

🟢 **The report is right that the hash is 26-39%** - it measures 38%.

🔴 **And it does not matter.** `UX5` puts the reaction threshold at 100 ms. At the batch count the report itself names, a keystroke costs 2.5 ms - **forty times under** - and the curve is linear, so the threshold falls around eight hundred batches. Same class as `P8`.

Three reasons it stays without code, two of them older than this session (`O145`, your decision of 2026-08-27): the fix would be a defence nothing can redden; throttling invalidates the live-validation guards; and the only real remaining fix touches **`recipe_hash`**, which goes into somebody else's manifest - untouchable rule 10, not a performance question, for 9 ms at two hundred batches.

🟢 **`P5` already took part of it for free:** `O145` recorded 14.24 ms at 100 batches; it is now **11.93 ms**, because `Parse` stopped parsing twice.

## Verification

- full `go test -tags "$(cat .github/build-tags)" ./...` - green
- `python tools/preflight.py --quick` - all 12 checks pass
- `try-named.py` on both recipe guards - 3 mutations, all caught
- 5 fuzz targets, 20s each - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)